### PR TITLE
Serve /alpaca.pac to send non-DIRECT requests to alpaca

### DIFF
--- a/contextid.go
+++ b/contextid.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"context"
+	"net/http"
+)
+
+// AddContextID wraps a http.Handler to add a monotonically increasing
+// uint to the context of the http.Request with the key "id" (string)
+// as it passes through the request to the next handler.
+func AddContextID(next http.Handler) http.Handler {
+	ids := make(chan uint)
+	go func() {
+		for id := uint(0); ; id++ {
+			ids <- id
+		}
+	}()
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		ctx := context.WithValue(req.Context(), "id", <-ids)
+		next.ServeHTTP(w, req.WithContext(ctx))
+	})
+}

--- a/contextid_test.go
+++ b/contextid_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func getIdFromRequest(t *testing.T, server *httptest.Server) uint {
+	res, err := http.Get(server.URL)
+	assert.NoError(t, err)
+	b, err := ioutil.ReadAll(res.Body)
+	assert.NoError(t, err)
+	id, err := strconv.ParseUint(string(b), 10, 64)
+	assert.NoError(t, err)
+	return uint(id)
+}
+
+func TestContextId(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := r.Context().Value("id")
+		_, err := w.Write([]byte(strconv.FormatUint(uint64(id.(uint)), 10)))
+		assert.NoError(t, err)
+	})
+	server := httptest.NewServer(AddContextID(handler))
+	defer server.Close()
+	id0 := getIdFromRequest(t, server)
+	assert.Equal(t, id0, uint(0))
+	id1 := getIdFromRequest(t, server)
+	assert.Equal(t, id1, uint(1))
+}

--- a/main.go
+++ b/main.go
@@ -85,7 +85,7 @@ func main() {
 	s := &http.Server{
 		// Set the addr to localhost so that we only listen locally.
 		Addr:    fmt.Sprintf("localhost:%d", *port),
-		Handler: AddContextID(proxyHandler.WrapHandler(mux)),
+		Handler: AddContextID(proxyHandler.WrapHandler(RequestLogger(mux))),
 		// TODO: Implement HTTP/2 support. In the meantime, set TLSNextProto to a non-nil
 		// value to disable HTTP/2.
 		TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler)),

--- a/main.go
+++ b/main.go
@@ -83,7 +83,7 @@ func main() {
 	s := &http.Server{
 		// Set the addr to localhost so that we only listen locally.
 		Addr:    fmt.Sprintf("localhost:%d", *port),
-		Handler: handler,
+		Handler: AddContextID(handler),
 		// TODO: Implement HTTP/2 support. In the meantime, set TLSNextProto to a non-nil
 		// value to disable HTTP/2.
 		TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler)),

--- a/main.go
+++ b/main.go
@@ -71,6 +71,7 @@ func main() {
 	var handler http.Handler = mux
 	handler = RequestLogger(handler)
 	handler = proxyHandler.WrapHandler(handler)
+	handler = proxyFinder.WrapHandler(handler)
 	handler = AddContextID(handler)
 
 	s := &http.Server{

--- a/main.go
+++ b/main.go
@@ -63,9 +63,11 @@ func main() {
 		}
 	}
 
-	proxyFinder := NewProxyFinder(pacURL)
+	pacWrapper := NewPACWrapper(PACData{*port, pacURL, a.domain, a.username})
+	proxyFinder := NewProxyFinder(pacURL, pacWrapper)
 	proxyHandler := NewProxyHandler(proxyFinder.findProxyForRequest, &a)
 	mux := http.NewServeMux()
+	pacWrapper.SetupHandlers(mux)
 
 	// build the handler by wrapping middleware upon middleware
 	var handler http.Handler = mux

--- a/netmonitor.go
+++ b/netmonitor.go
@@ -46,7 +46,7 @@ func setsAreEqual(a, b map[string]struct{}) bool {
 	if len(a) != len(b) {
 		return false
 	}
-	for k, _ := range a {
+	for k := range a {
 		if _, ok := b[k]; !ok {
 			return false
 		}

--- a/pacfetcher_test.go
+++ b/pacfetcher_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func pacjsHandler(pacjs string) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) { w.Write([]byte(pacjs)) }
+	return func(w http.ResponseWriter, r *http.Request) { w.Write([]byte(pacjs)) } // nolint:errcheck
 }
 
 type fakeNetMonitor struct {

--- a/pacfinder.go
+++ b/pacfinder.go
@@ -32,7 +32,7 @@ func findPACURLForDarwin() (string, error) {
 	if err := cmd.Start(); err != nil {
 		return "", err
 	}
-	defer cmd.Wait()
+	defer cmd.Wait() // nolint:errcheck
 	r := bufio.NewReader(stdout)
 	// Discard the first line, which isn't the name of a network service.
 	if _, err := r.ReadString('\n'); err != nil {
@@ -68,7 +68,7 @@ func getAutoProxyURL(networkService string) (string, error) {
 	if err := cmd.Start(); err != nil {
 		return "", err
 	}
-	defer cmd.Wait()
+	defer cmd.Wait() // nolint:errcheck
 	r := bufio.NewReader(stdout)
 	for {
 		line, err := r.ReadString('\n')

--- a/pacwrapper.go
+++ b/pacwrapper.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"log"
+	"net/http"
+	"text/template"
+)
+
+type PACData struct {
+	Port     int
+	PACURL   string
+	Domain   string
+	Username string
+}
+
+type pacData struct {
+	PACData
+	PAC string
+}
+
+type PACWrapper struct {
+	data      pacData
+	tmpl      *template.Template
+	alpacaPAC string
+}
+
+// PACWrapper template for serving a PAC file to point at alpaca or DIRECT.
+// If we have a valid PAC file, we wrap that PAC file with a wrapper
+// function that only returns "DIRECT" or "localhost:port". If we do not
+// have a PAC file, the PAC function we serve only returns "DIRECT", which
+// should prevent all requests reaching us.
+var pacWrapTmpl = `// Wrapped for and by alpaca
+function FindProxyForURL(url, host) {
+{{ if .PAC }}
+  return FindProxyForURL(url, host) === "DIRECT" ? "DIRECT" : "PROXY localhost:{{.Port}}";
+{{.PAC}}
+{{ else }}
+  return "DIRECT";
+{{ end }}
+}
+`
+
+func NewPACWrapper(data PACData) *PACWrapper {
+	t := template.Must(template.New("alpaca").Parse(pacWrapTmpl))
+	return &PACWrapper{pacData{data, ""}, t, ""}
+}
+
+func (pw *PACWrapper) Wrap(pacjs []byte) {
+	pac := string(pacjs)
+	if pac == pw.data.PAC && pw.alpacaPAC != "" {
+		return
+	}
+	pw.data.PAC = pac
+	b := &bytes.Buffer{}
+	if err := pw.tmpl.Execute(b, pw.data); err != nil {
+		log.Printf("error executing PAC wrap template: %v\n", err)
+		return
+	}
+	pw.alpacaPAC = b.String()
+}
+
+func (pw *PACWrapper) SetupHandlers(mux *http.ServeMux) {
+	mux.HandleFunc("/proxy.pac", pw.handleProxyPAC)
+	mux.HandleFunc("/alpaca.pac", pw.handleAlpacaPAC)
+}
+
+func (pw *PACWrapper) handleProxyPAC(w http.ResponseWriter, req *http.Request) {
+	pw.handlePAC(w, req, pw.data.PAC)
+}
+
+func (pw *PACWrapper) handleAlpacaPAC(w http.ResponseWriter, req *http.Request) {
+	pw.handlePAC(w, req, pw.alpacaPAC)
+}
+
+func (pw *PACWrapper) handlePAC(w http.ResponseWriter, req *http.Request, pac string) {
+	if req.Method != "GET" {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	w.Header().Set("Content-Type", "application/x-ns-proxy-autoconfig")
+	if _, err := w.Write([]byte(pac)); err != nil {
+		log.Printf("Error writing PAC to response: %v\n", err)
+	}
+}

--- a/pacwrapper_test.go
+++ b/pacwrapper_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWrapPAC(t *testing.T) {
+	pw := NewPACWrapper(PACData{1234, "http://pacserver/proxy.pac", "domain", "username"})
+	pac := `function FindProxyForURL(url, host) { return "DIRECT" }`
+	pw.Wrap([]byte(pac))
+	assert.Contains(t, pw.alpacaPAC, pac)
+	assert.Contains(t, pw.alpacaPAC, `"DIRECT" : "PROXY localhost:1234"`)
+}
+
+func TestWrapEmptyPAC(t *testing.T) {
+	pw := NewPACWrapper(PACData{1234, "http://pacserver/proxy.pac", "domain", "username"})
+	pw.Wrap(nil)
+	assert.Contains(t, pw.alpacaPAC, `return "DIRECT"`)
+}
+
+func TestProxyPACServe(t *testing.T) {
+	pw := NewPACWrapper(PACData{1234, "http://pacserver/proxy.pac", "domain", "username"})
+	pac := `function FindProxyForURL(url, host) { return "DIRECT" }`
+	pw.Wrap([]byte(pac))
+	mux := http.NewServeMux()
+	pw.SetupHandlers(mux)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/proxy.pac")
+	assert.NoError(t, err)
+
+	assert.Equal(t, resp.StatusCode, http.StatusOK)
+	assert.Equal(t, "application/x-ns-proxy-autoconfig", resp.Header.Get("Content-Type"))
+	body, err := ioutil.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, string(body), pac)
+	resp.Body.Close()
+}
+
+func TestAlpacaPACServe(t *testing.T) {
+	pw := NewPACWrapper(PACData{1234, "http://pacserver/proxy.pac", "domain", "username"})
+	pac := `function FindProxyForURL(url, host) { return "DIRECT" }`
+	pw.Wrap([]byte(pac))
+	mux := http.NewServeMux()
+	pw.SetupHandlers(mux)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/alpaca.pac")
+	assert.NoError(t, err)
+
+	assert.Equal(t, resp.StatusCode, http.StatusOK)
+	assert.Equal(t, "application/x-ns-proxy-autoconfig", resp.Header.Get("Content-Type"))
+	b, err := ioutil.ReadAll(resp.Body)
+	body := string(b)
+	assert.NoError(t, err)
+	assert.Contains(t, body, pac)
+	assert.Contains(t, body, `"DIRECT" : "PROXY localhost:1234"`)
+	resp.Body.Close()
+}

--- a/proxy.go
+++ b/proxy.go
@@ -80,8 +80,8 @@ func (ph ProxyHandler) handleConnect(w http.ResponseWriter, req *http.Request) {
 	// Kick off goroutines to copy data in each direction. Whichever goroutine finishes first
 	// will close the Reader for the other goroutine, forcing any blocked copy to unblock. This
 	// prevents any goroutine from blocking indefinitely (which will leak a file descriptor).
-	go func() { io.Copy(server, client); server.Close() }()
-	go func() { io.Copy(client, server); client.Close() }()
+	go func() { io.Copy(server, client); server.Close() }() // nolint:errcheck
+	go func() { io.Copy(client, server); client.Close() }() // nolint:errcheck
 }
 
 func connectViaProxy(w http.ResponseWriter, req *http.Request, proxy string, auth *authenticator) net.Conn {

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -5,8 +5,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"io"
 	"io/ioutil"
 	"net"
@@ -14,6 +12,9 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type testServer struct {
@@ -74,7 +75,9 @@ func TestGetViaProxy(t *testing.T) {
 	requests := make(chan string, 2)
 	server := httptest.NewServer(testServer{requests})
 	defer server.Close()
-	proxy := httptest.NewServer(testProxy{requests, "proxy", newDirectProxy()})
+	// Proxy request should not go to the mux. The empty mux will always return 404
+	mux := http.NewServeMux()
+	proxy := httptest.NewServer(testProxy{requests, "proxy", newDirectProxy().WrapHandler(mux)})
 	defer proxy.Close()
 	tr := &http.Transport{Proxy: proxyServer(t, proxy)}
 	testGetRequest(t, tr, server.URL)
@@ -87,13 +90,29 @@ func TestGetOverTlsViaProxy(t *testing.T) {
 	requests := make(chan string, 2)
 	server := httptest.NewTLSServer(testServer{requests})
 	defer server.Close()
-	proxy := httptest.NewServer(testProxy{requests, "proxy", newDirectProxy()})
+	// Proxy request should not go to the mux. The empty mux will always return 404
+	mux := http.NewServeMux()
+	proxy := httptest.NewServer(testProxy{requests, "proxy", newDirectProxy().WrapHandler(mux)})
 	defer proxy.Close()
 	tr := &http.Transport{Proxy: proxyServer(t, proxy), TLSClientConfig: tlsConfig(server)}
 	testGetRequest(t, tr, server.URL)
 	require.Len(t, requests, 2)
 	assert.Equal(t, "CONNECT to proxy", <-requests)
 	assert.Equal(t, "GET to server", <-requests)
+}
+
+func TestGetOriginURLsNotProxied(t *testing.T) {
+	requests := make(chan string, 2)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/origin", func(w http.ResponseWriter, req *http.Request) {
+		_, err := w.Write([]byte("Hello, client\n"))
+		require.NoError(t, err)
+	})
+	proxy := httptest.NewServer(testProxy{requests, "proxy", newDirectProxy().WrapHandler(mux)})
+	defer proxy.Close()
+	testGetRequest(t, &http.Transport{}, proxy.URL+"/origin")
+	require.Len(t, requests, 1)
+	assert.Equal(t, "GET to proxy", <-requests)
 }
 
 func TestGetViaTwoProxies(t *testing.T) {

--- a/proxyfinder.go
+++ b/proxyfinder.go
@@ -14,11 +14,12 @@ import (
 type ProxyFinder struct {
 	runner  *PACRunner
 	fetcher *pacFetcher
+	wrapper *PACWrapper
 	sync.Mutex
 }
 
-func NewProxyFinder(pacurl string) *ProxyFinder {
-	pf := &ProxyFinder{}
+func NewProxyFinder(pacurl string, wrapper *PACWrapper) *ProxyFinder {
+	pf := &ProxyFinder{wrapper: wrapper}
 	if len(pacurl) == 0 {
 		log.Println("No PAC URL specified or detected; all requests will be made directly")
 	} else if _, err := url.Parse(pacurl); err != nil {
@@ -45,10 +46,15 @@ func (pf *ProxyFinder) checkForUpdates() {
 	defer pf.Unlock()
 	pacjs := pf.fetcher.download()
 	if pacjs == nil {
+		if !pf.fetcher.isConnected() {
+			pf.wrapper.Wrap(nil)
+		}
 		return
 	}
 	if err := pf.runner.Update(pacjs); err != nil {
 		log.Printf("Error running PAC JS: %q\n", err)
+	} else {
+		pf.wrapper.Wrap(pacjs)
 	}
 }
 

--- a/proxyfinder.go
+++ b/proxyfinder.go
@@ -26,8 +26,7 @@ func NewProxyFinder(pacurl string) *ProxyFinder {
 func (pf *ProxyFinder) checkForUpdates() {
 	pf.Lock()
 	defer pf.Unlock()
-	var pacjs []byte
-	pacjs = pf.fetcher.download()
+	pacjs := pf.fetcher.download()
 	if pacjs == nil {
 		return
 	}

--- a/proxyfinder.go
+++ b/proxyfinder.go
@@ -18,7 +18,15 @@ type ProxyFinder struct {
 }
 
 func NewProxyFinder(pacurl string) *ProxyFinder {
-	pf := &ProxyFinder{runner: new(PACRunner), fetcher: newPACFetcher(pacurl)}
+	pf := &ProxyFinder{}
+	if len(pacurl) == 0 {
+		log.Println("No PAC URL specified or detected; all requests will be made directly")
+	} else if _, err := url.Parse(pacurl); err != nil {
+		log.Fatalf("Couldn't find a valid PAC URL: %v", pacurl)
+	} else {
+		pf.runner = new(PACRunner)
+		pf.fetcher = newPACFetcher(pacurl)
+	}
 	pf.checkForUpdates()
 	return pf
 }
@@ -36,11 +44,16 @@ func (pf *ProxyFinder) checkForUpdates() {
 }
 
 func (pf *ProxyFinder) findProxyForRequest(req *http.Request) (*url.URL, error) {
-	pf.checkForUpdates()
-	if !pf.fetcher.isConnected() {
+	id := req.Context().Value("id")
+	if pf.fetcher == nil {
+		log.Printf(`[%d] %s %s via "DIRECT"`, id, req.Method, req.URL)
 		return nil, nil
 	}
-	id := req.Context().Value("id")
+	pf.checkForUpdates()
+	if !pf.fetcher.isConnected() {
+		log.Printf(`[%d] %s %s via "DIRECT" (not connected)`, id, req.Method, req.URL)
+		return nil, nil
+	}
 	s, err := pf.runner.FindProxyForURL(req.URL)
 	if err != nil {
 		return nil, err

--- a/proxyfinder_test.go
+++ b/proxyfinder_test.go
@@ -30,7 +30,8 @@ func TestFindProxyForRequest(t *testing.T) {
 			js := fmt.Sprintf("function FindProxyForURL(url, host) { %s }", test.body)
 			server := httptest.NewServer(http.HandlerFunc(pacjsHandler(js)))
 			defer server.Close()
-			pf := NewProxyFinder(server.URL)
+			pw := NewPACWrapper(PACData{1, server.URL, "domain", "username"})
+			pf := NewProxyFinder(server.URL, pw)
 			req := httptest.NewRequest(http.MethodGet, "https://www.test", nil)
 			req = req.WithContext(context.WithValue(req.Context(), "id", i))
 			proxy, err := pf.findProxyForRequest(req)
@@ -50,7 +51,9 @@ func TestFindProxyForRequest(t *testing.T) {
 }
 
 func TestFallbackToDirectWhenNotConnected(t *testing.T) {
-	pf := NewProxyFinder("http://pacserver.invalid/nonexistent.pac")
+	url := "http://pacserver.invalid/nonexistent.pac"
+	pw := NewPACWrapper(PACData{1, url, "domain", "username"})
+	pf := NewProxyFinder(url, pw)
 	req := httptest.NewRequest(http.MethodGet, "http://www.test", nil)
 	proxy, err := pf.findProxyForRequest(req)
 	require.Nil(t, err)

--- a/requestlogger.go
+++ b/requestlogger.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"log"
+	"net/http"
+)
+
+type statusWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func (w *statusWriter) WriteHeader(status int) {
+	w.status = status
+	w.ResponseWriter.WriteHeader(status)
+}
+
+func RequestLogger(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		sw := &statusWriter{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(sw, req)
+		log.Printf("[%v] %d %s %s\n", req.Context().Value("id"), sw.status, req.Method, req.URL)
+	})
+}

--- a/requestlogger_test.go
+++ b/requestlogger_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"bytes"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequestLogger(t *testing.T) {
+	tests := map[string]struct {
+		status  int
+		wrapper func(http.Handler) http.Handler
+		out     string
+	}{
+		"No Status":    {0, nil, "[<nil>] 200 GET /"},
+		"Given Status": {http.StatusNotFound, nil, "[<nil>] 404 GET /"},
+		"Context":      {http.StatusOK, AddContextID, "[0] 200 GET /"},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			b := &bytes.Buffer{}
+			log.SetOutput(b)
+			var handler http.Handler // nolint:gosimple
+			handler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				if tt.status != 0 {
+					w.WriteHeader(tt.status)
+				}
+			})
+			handler = RequestLogger(handler)
+			if tt.wrapper != nil {
+				handler = tt.wrapper(handler)
+			}
+			server := httptest.NewServer(handler)
+			defer server.Close()
+			_, err := http.Get(server.URL)
+			assert.NoError(t, err)
+			log.SetOutput(os.Stderr)
+			assert.Contains(t, b.String(), tt.out)
+		})
+	}
+}


### PR DESCRIPTION
Serve a PAC file on `/alpaca.pac` that only returns `DIRECT` or `PROXY localhost:<listen-port>` (usually `3128`). If the PAC file that alpaca is using would return `DIRECT` for a URL, the wrapped PAC also returns `DIRECT`. For everything else, it returns a proxy directive to send traffic to alpaca. If alpaca does not have a PAC file (wrong network, etc), then the PAC function only returns `DIRECT`.

This allows the system (Mac OSX, Gnome, etc) to use alpaca as the proxy, and to configure alpaca with the network proxy URL. When the system evaluates a URL with the wrapped PAC file and gets a DIRECT response, it will not proxy through alpaca and go direct instead. This helps with the odd application that doesn't seem to handle going through a proxy at all. It also means that when you're off the network that serves the PAC file, no requests go through alpaca. This makes alpaca work well as a whole-system proxy instead of just for CLI apps as originally intended.

A bit of refactoring and lint fixes made it into this PR. The most significant change would be the use of http handler wrappers (also known in some circles as http middleware). Once the code went from 1 to >1 handlers, it made sense to factor out some functionality into a handler wrapper. Some additional functionality was added that way too.

Please review this commit-by-commit and read the commit messages. I hope that makes it clearer to understand the changes and their reason. I'm happy to entertain the most nit-picky requests/reviews, so don't hold back, no matter how trivial it seems.

Fixes: #14 