### PR TITLE
Serve /alpaca.pac to send non-DIRECT requests to alpaca

### DIFF
--- a/contextid.go
+++ b/contextid.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"context"
+	"net/http"
+)
+
+// AddContextID wraps a http.Handler to add a strictly increasing
+// uint to the context of the http.Request with the key "id" (string)
+// as it passes through the request to the next handler.
+func AddContextID(next http.Handler) http.Handler {
+	// TODO(#17): Use sync/atomic AddUint64 instead of channel/goroutine
+	ids := make(chan uint)
+	go func() {
+		for id := uint(0); ; id++ {
+			ids <- id
+		}
+	}()
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		// TODO(#17): Use package scoped type instead of string for key
+		ctx := context.WithValue(req.Context(), "id", <-ids)
+		next.ServeHTTP(w, req.WithContext(ctx))
+	})
+}

--- a/contextid_test.go
+++ b/contextid_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func getIDFromRequest(t *testing.T, server *httptest.Server) uint {
+	res, err := http.Get(server.URL)
+	require.NoError(t, err)
+	b, err := ioutil.ReadAll(res.Body)
+	require.NoError(t, err)
+	id, err := strconv.ParseUint(string(b), 10, 64)
+	require.NoError(t, err)
+	return uint(id)
+}
+
+func TestContextID(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id, ok := r.Context().Value("id").(uint)
+		assert.True(t, ok, "Unexpected type for context id value")
+		_, err := w.Write([]byte(strconv.FormatUint(uint64(id), 10)))
+		require.NoError(t, err)
+	})
+	server := httptest.NewServer(AddContextID(handler))
+	defer server.Close()
+	assert.Equal(t, uint(0), getIDFromRequest(t, server))
+	assert.Equal(t, uint(1), getIDFromRequest(t, server))
+}

--- a/main.go
+++ b/main.go
@@ -85,7 +85,7 @@ func main() {
 	s := &http.Server{
 		// Set the addr to localhost so that we only listen locally.
 		Addr:    fmt.Sprintf("localhost:%d", *port),
-		Handler: AddContextID(proxyHandler.WrapHandler(mux)),
+		Handler: AddContextID(proxyHandler.WrapHandler(RequestLogger(mux))),
 		// TODO: Implement HTTP/2 support. In the meantime, set TLSNextProto to a non-nil
 		// value to disable HTTP/2.
 		TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler)),

--- a/main.go
+++ b/main.go
@@ -83,7 +83,7 @@ func main() {
 	s := &http.Server{
 		// Set the addr to localhost so that we only listen locally.
 		Addr:    fmt.Sprintf("localhost:%d", *port),
-		Handler: handler,
+		Handler: AddContextID(handler),
 		// TODO: Implement HTTP/2 support. In the meantime, set TLSNextProto to a non-nil
 		// value to disable HTTP/2.
 		TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler)),

--- a/main.go
+++ b/main.go
@@ -63,9 +63,11 @@ func main() {
 		}
 	}
 
-	proxyFinder := NewProxyFinder(pacURL)
+	pacWrapper := NewPACWrapper(PACData{Port: *port})
+	proxyFinder := NewProxyFinder(pacURL, pacWrapper)
 	proxyHandler := NewProxyHandler(proxyFinder.findProxyForRequest, &a)
 	mux := http.NewServeMux()
+	pacWrapper.SetupHandlers(mux)
 
 	// build the handler by wrapping middleware upon middleware
 	var handler http.Handler = mux

--- a/main.go
+++ b/main.go
@@ -71,6 +71,7 @@ func main() {
 	var handler http.Handler = mux
 	handler = RequestLogger(handler)
 	handler = proxyHandler.WrapHandler(handler)
+	handler = proxyFinder.WrapHandler(handler)
 	handler = AddContextID(handler)
 
 	s := &http.Server{

--- a/pacwrapper.go
+++ b/pacwrapper.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bytes"
+	"log"
+	"net/http"
+	"text/template"
+)
+
+// PACData contains program configuration to be made available to the pacWrapTmpl.
+type PACData struct {
+	Port     int
+}
+
+type pacData struct {
+	PACData
+	UpstreamPAC string
+}
+
+type PACWrapper struct {
+	data      pacData
+	tmpl      *template.Template
+	alpacaPAC string
+}
+
+// PACWrapper template for serving a PAC file to point at alpaca or DIRECT. If we have a valid
+// PAC file, we wrap that PAC file with a wrapper function that only returns "DIRECT" or
+// "localhost:port". If we do not have a PAC file, the PAC function we serve only returns "DIRECT",
+// which should prevent all requests reaching us.
+var pacWrapTmpl = `// Wrapped for and by alpaca
+function FindProxyForURL(url, host) {
+{{ if .UpstreamPAC }}
+  return FindProxyForURL(url, host) === "DIRECT" ? "DIRECT" : "PROXY localhost:{{.Port}}";
+{{.UpstreamPAC}}
+{{ else }}
+  return "DIRECT";
+{{ end }}
+}
+`
+
+func NewPACWrapper(data PACData) *PACWrapper {
+	t := template.Must(template.New("alpaca").Parse(pacWrapTmpl))
+	return &PACWrapper{pacData{data, ""}, t, ""}
+}
+
+func (pw *PACWrapper) Wrap(pacjs []byte) {
+	pac := string(pacjs)
+	if pac == pw.data.UpstreamPAC && pw.alpacaPAC != "" {
+		return
+	}
+	pw.data.UpstreamPAC = pac
+	b := &bytes.Buffer{}
+	if err := pw.tmpl.Execute(b, pw.data); err != nil {
+		log.Printf("error executing PAC wrap template: %v\n", err)
+		return
+	}
+	pw.alpacaPAC = b.String()
+}
+
+func (pw *PACWrapper) SetupHandlers(mux *http.ServeMux) {
+	mux.HandleFunc("/alpaca.pac", pw.handlePAC)
+}
+
+func (pw *PACWrapper) handlePAC(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodGet {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	w.Header().Set("Content-Type", "application/x-ns-proxy-autoconfig")
+	if _, err := w.Write([]byte(pw.alpacaPAC)); err != nil {
+		log.Printf("Error writing PAC to response: %v\n", err)
+	}
+}

--- a/pacwrapper_test.go
+++ b/pacwrapper_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWrapPAC(t *testing.T) {
+	pw := NewPACWrapper(PACData{Port: 1234})
+	pac := `function FindProxyForURL(url, host) { return "DIRECT" }`
+	pw.Wrap([]byte(pac))
+	assert.Contains(t, pw.alpacaPAC, pac)
+	assert.Contains(t, pw.alpacaPAC, `"DIRECT" : "PROXY localhost:1234"`)
+}
+
+func TestWrapEmptyPAC(t *testing.T) {
+	pw := NewPACWrapper(PACData{Port: 1234})
+	pw.Wrap(nil)
+	assert.Contains(t, pw.alpacaPAC, `return "DIRECT"`)
+}
+
+func TestPACServe(t *testing.T) {
+	pw := NewPACWrapper(PACData{Port: 1234})
+	pac := `function FindProxyForURL(url, host) { return "DIRECT" }`
+	pw.Wrap([]byte(pac))
+	mux := http.NewServeMux()
+	pw.SetupHandlers(mux)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/alpaca.pac")
+	require.NoError(t, err)
+
+	assert.Equal(t, resp.StatusCode, http.StatusOK)
+	assert.Equal(t, "application/x-ns-proxy-autoconfig", resp.Header.Get("Content-Type"))
+	b, err := ioutil.ReadAll(resp.Body)
+	body := string(b)
+	require.NoError(t, err)
+	assert.Contains(t, body, pac)
+	assert.Contains(t, body, `"DIRECT" : "PROXY localhost:1234"`)
+	resp.Body.Close()
+}

--- a/proxyfinder_test.go
+++ b/proxyfinder_test.go
@@ -30,7 +30,8 @@ func TestFindProxyForRequest(t *testing.T) {
 			js := fmt.Sprintf("function FindProxyForURL(url, host) { %s }", test.body)
 			server := httptest.NewServer(http.HandlerFunc(pacjsHandler(js)))
 			defer server.Close()
-			pf := NewProxyFinder(server.URL)
+			pw := NewPACWrapper(PACData{Port: 1})
+			pf := NewProxyFinder(server.URL, pw)
 			req := httptest.NewRequest(http.MethodGet, "https://www.test", nil)
 			req = req.WithContext(context.WithValue(req.Context(), "id", i))
 			proxy, err := pf.findProxyForRequest(req)
@@ -50,7 +51,9 @@ func TestFindProxyForRequest(t *testing.T) {
 }
 
 func TestFallbackToDirectWhenNotConnected(t *testing.T) {
-	pf := NewProxyFinder("http://pacserver.invalid/nonexistent.pac")
+	url := "http://pacserver.invalid/nonexistent.pac"
+	pw := NewPACWrapper(PACData{Port: 1})
+	pf := NewProxyFinder(url, pw)
 	req := httptest.NewRequest(http.MethodGet, "http://www.test", nil)
 	proxy, err := pf.findProxyForRequest(req)
 	require.Nil(t, err)

--- a/requestlogger.go
+++ b/requestlogger.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"log"
+	"net/http"
+)
+
+type statusWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func (w *statusWriter) WriteHeader(status int) {
+	w.status = status
+	w.ResponseWriter.WriteHeader(status)
+}
+
+func RequestLogger(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		sw := &statusWriter{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(sw, req)
+		log.Printf("[%v] %d %s %s\n", req.Context().Value("id"), sw.status, req.Method, req.URL)
+	})
+}

--- a/requestlogger_test.go
+++ b/requestlogger_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bytes"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestLogger(t *testing.T) {
+	tests := map[string]struct {
+		status  int
+		wrapper func(http.Handler) http.Handler
+		out     string
+	}{
+		"No Status":    {0, nil, "[<nil>] 200 GET /"},
+		"Given Status": {http.StatusNotFound, nil, "[<nil>] 404 GET /"},
+		"Context":      {http.StatusOK, AddContextID, "[0] 200 GET /"},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			b := &bytes.Buffer{}
+			log.SetOutput(b)
+			hfunc := func(w http.ResponseWriter, req *http.Request) {
+				if tt.status != 0 {
+					w.WriteHeader(tt.status)
+				}
+			}
+			var handler http.Handler = http.HandlerFunc(hfunc)
+			handler = RequestLogger(handler)
+			if tt.wrapper != nil {
+				handler = tt.wrapper(handler)
+			}
+			server := httptest.NewServer(handler)
+			defer server.Close()
+			_, err := http.Get(server.URL)
+			require.NoError(t, err)
+			log.SetOutput(os.Stderr)
+			assert.Contains(t, b.String(), tt.out)
+		})
+	}
+}


### PR DESCRIPTION
Serve a PAC file on `/alpaca.pac` that only returns `DIRECT` or `PROXY localhost:<listen-port>` (usually `3128`). If the PAC file that alpaca is using would return `DIRECT` for a URL, the wrapped PAC also returns `DIRECT`. For everything else, it returns a proxy directive to send traffic to alpaca. If alpaca does not have a PAC file (wrong network, etc), then the PAC function only returns `DIRECT`.

This allows the system (Mac OSX, Gnome, etc) to use alpaca as the proxy, and to configure alpaca with the network proxy URL. When the system evaluates a URL with the wrapped PAC file and gets a DIRECT response, it will not proxy through alpaca and go direct instead. This helps with the odd application that doesn't seem to handle going through a proxy at all. It also means that when you're off the network that serves the PAC file, no requests go through alpaca. This makes alpaca work well as a whole-system proxy instead of just for CLI apps as originally intended.

A bit of refactoring and lint fixes made it into this PR. The most significant change would be the use of http handler wrappers (also known in some circles as http middleware). Once the code went from 1 to >1 handlers, it made sense to factor out some functionality into a handler wrapper. Some additional functionality was added that way too.

Please review this commit-by-commit and read the commit messages. I hope that makes it clearer to understand the changes and their reason. I'm happy to entertain the most nit-picky requests/reviews, so don't hold back, no matter how trivial it seems.

Fixes: #14 