### PR TITLE
Don't call checkForUpdates without a fetcher

### DIFF
--- a/proxyfinder.go
+++ b/proxyfinder.go
@@ -27,8 +27,8 @@ func NewProxyFinder(pacurl string, wrapper *PACWrapper) *ProxyFinder {
 	} else {
 		pf.runner = new(PACRunner)
 		pf.fetcher = newPACFetcher(pacurl)
+		pf.checkForUpdates()
 	}
-	pf.checkForUpdates()
 	return pf
 }
 

--- a/proxyfinder_test.go
+++ b/proxyfinder_test.go
@@ -59,3 +59,13 @@ func TestFallbackToDirectWhenNotConnected(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, proxy)
 }
+
+func TestFallbackToDirectWhenNoPACURL(t *testing.T) {
+	url := ""
+	pw := NewPACWrapper(PACData{Port: 1})
+	pf := NewProxyFinder(url, pw)
+	req := httptest.NewRequest(http.MethodGet, "http://www.test", nil)
+	proxy, err := pf.findProxyForRequest(req)
+	require.NoError(t, err)
+	assert.Nil(t, proxy)
+}


### PR DESCRIPTION
`ProxyFinder.checkForUpdates()` should only be called if `pf.fetcher` is
not nil. It does this on the HTTP serving path, but not on the initial
call. Move the call to `checkForUpdates()` inside the branch that
creates the pacfetcher.

Fixes this bug:

    sam@sam-desktop:~/alpaca$ go build && ./alpaca
    2019/09/19 19:13:28 proxyfinder.go:24: No PAC URL specified or detected; all requests will be made directly
    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x855e7e]

    goroutine 1 [running]:
    main.(*pacFetcher).download(0x0, 0x0, 0x0, 0x0)
            /home/sam/alpaca/pacfetcher.go:51 +0x4e
    main.(*ProxyFinder).checkForUpdates(0xc00000e0c0)
            /home/sam/alpaca/proxyfinder.go:50 +0x76
    main.NewProxyFinder(0x0, 0x0, 0xc000170480, 0x0)
            /home/sam/alpaca/proxyfinder.go:31 +0xa9
    main.main()
            /home/sam/alpaca/main.go:67 +0x2b8