### PR TITLE
Return a pointer to an authenticator

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,13 +49,10 @@ func main() {
 		}
 		a = &authenticator{domain: *domain, username: *username, password: string(buf)}
 	} else if getCredentialsFromKeyring != nil {
-		tmp, err := getCredentialsFromKeyring()
+		var err error
+		a, err = getCredentialsFromKeyring()
 		if err != nil {
 			log.Printf("NoMAD credentials not found, disabling proxy auth: %v", err)
-		} else {
-			log.Printf("Found NoMAD credentails for %s\\%s in system keychain",
-				tmp.domain, tmp.username)
-			a = tmp
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
-var getCredentialsFromKeyring func() (authenticator, error)
+var getCredentialsFromKeyring func() (*authenticator, error)
 
 func whoAmI() string {
 	me, err := user.Current()
@@ -39,7 +39,7 @@ func main() {
 		}
 	}
 
-	var a authenticator
+	var a *authenticator
 	if *domain != "" {
 		fmt.Printf("Password (for %s\\%s): ", *domain, *username)
 		buf, err := terminal.ReadPassword(int(os.Stdin.Fd()))
@@ -47,7 +47,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("Error reading password from stdin: %v", err)
 		}
-		a = authenticator{domain: *domain, username: *username, password: string(buf)}
+		a = &authenticator{domain: *domain, username: *username, password: string(buf)}
 	} else if getCredentialsFromKeyring != nil {
 		tmp, err := getCredentialsFromKeyring()
 		if err != nil {
@@ -61,7 +61,7 @@ func main() {
 
 	pacWrapper := NewPACWrapper(PACData{Port: *port})
 	proxyFinder := NewProxyFinder(pacURL, pacWrapper)
-	proxyHandler := NewProxyHandler(proxyFinder.findProxyForRequest, &a)
+	proxyHandler := NewProxyHandler(proxyFinder.findProxyForRequest, a)
 	mux := http.NewServeMux()
 	pacWrapper.SetupHandlers(mux)
 

--- a/nomad_darwin.go
+++ b/nomad_darwin.go
@@ -41,22 +41,22 @@ func readPasswordFromKeychain(userPrincipal string) string {
 	return string(results[0].Data)
 }
 
-func getCredentialsFromNoMAD() (authenticator, error) {
+func getCredentialsFromNoMAD() (*authenticator, error) {
 	useKeychain, err := readDefaultForNoMAD("UseKeychain")
 	if err != nil {
-		return authenticator{}, err
+		return nil, err
 	} else if useKeychain != "1" {
-		return authenticator{}, errors.New(`NoMAD found, but UseKeychain != 1. To sync your AD password to the system keychain (and have Alpaca automatically retrieve it from there) open NoMAD's Preferences dialog and check "Use Keychain".`)
+		return nil, errors.New("NoMAD found, but not configured to use keychain")
 	}
 	userPrincipal, err := readDefaultForNoMAD("UserPrincipal")
 	if err != nil {
-		return authenticator{}, err
+		return nil, err
 	}
 	substrs := strings.Split(userPrincipal, "@")
 	if len(substrs) != 2 {
-		return authenticator{}, errors.New("Couldn't retrieve AD domain and username from NoMAD.")
+		return nil, errors.New("Couldn't retrieve AD domain and username from NoMAD.")
 	}
 	user, domain := substrs[0], substrs[1]
 	password := readPasswordFromKeychain(userPrincipal)
-	return authenticator{domain, user, password}, nil
+	return &authenticator{domain, user, password}, nil
 }

--- a/nomad_darwin.go
+++ b/nomad_darwin.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"log"
 	"os/exec"
 	"strings"
 
@@ -58,5 +59,6 @@ func getCredentialsFromNoMAD() (*authenticator, error) {
 	}
 	user, domain := substrs[0], substrs[1]
 	password := readPasswordFromKeychain(userPrincipal)
+	log.Printf("Found NoMAD credentails for %s\\%s in system keychain", domain, user)
 	return &authenticator{domain, user, password}, nil
 }


### PR DESCRIPTION
This allows Alpaca to distinguish between having no credentials, and having a blank domain/username/password.