### PR TITLE
Retry PAC downloads after 2 seconds in case of failure

### DIFF
--- a/pacfetcher.go
+++ b/pacfetcher.go
@@ -14,6 +14,10 @@ import (
 // The maximum size (in bytes) allowed for a PAC script. At 1 MB, this matches the limit in Chrome.
 const maxResponseBytes = 1 * 1024 * 1024
 
+// The time to wait before retrying a failed PAC download. This is similar to Chrome's delay:
+// https://cs.chromium.org/chromium/src/net/proxy_resolution/proxy_resolution_service.cc?l=96&rcl=3db5f65968c3ecab3932c1ff7367ad28834f9502
+const delayAfterFailedDownload = 2 * time.Second
+
 type pacFetcher struct {
 	pacurl     string
 	monitor    netMonitor
@@ -55,7 +59,7 @@ func (pf *pacFetcher) download() []byte {
 	resp, err := pf.client.Get(pf.pacurl)
 	if err != nil {
 		log.Printf("Error downloading PAC file, retrying after 2 seconds: %q", err)
-		time.Sleep(2 * time.Second)
+		time.Sleep(delayAfterFailedDownload)
 		resp, err = pf.client.Get(pf.pacurl)
 		if err != nil {
 			log.Printf("Error downloading PAC file, giving up: %q", err)

--- a/pacfetcher.go
+++ b/pacfetcher.go
@@ -52,7 +52,8 @@ func requireOK(resp *http.Response, err error) (*http.Response, error) {
 	if err != nil {
 		return resp, err
 	} else if resp.StatusCode != http.StatusOK {
-		return resp, fmt.Errorf("expected status 200 OK, got %s", resp.Status)
+		resp.Body.Close()
+		return nil, fmt.Errorf("expected status 200 OK, got %s", resp.Status)
 	} else {
 		return resp, nil
 	}
@@ -67,9 +68,6 @@ func (pf *pacFetcher) download() []byte {
 	if err != nil {
 		// Sometimes, if we try to download too soon after a network change, the PAC
 		// download can fail. See https://github.com/samuong/alpaca/issues/8 for details.
-		if resp != nil && resp.Body != nil {
-			resp.Body.Close()
-		}
 		log.Printf("Error downloading PAC file, retrying after 2 seconds: %q", err)
 		time.Sleep(2 * time.Second)
 		resp, err = requireOK(pf.client.Get(pf.pacurl))

--- a/pacfetcher.go
+++ b/pacfetcher.go
@@ -57,7 +57,7 @@ func (pf *pacFetcher) download() []byte {
 	}
 	pf.connected = false
 	resp, err := pf.client.Get(pf.pacurl)
-	if err != nil {
+	if err != nil || resp.StatusCode != http.StatusOK {
 		log.Printf("Error downloading PAC file, retrying after 2 seconds: %q", err)
 		time.Sleep(delayAfterFailedDownload)
 		resp, err = pf.client.Get(pf.pacurl)

--- a/pacfetcher.go
+++ b/pacfetcher.go
@@ -14,10 +14,6 @@ import (
 // The maximum size (in bytes) allowed for a PAC script. At 1 MB, this matches the limit in Chrome.
 const maxResponseBytes = 1 * 1024 * 1024
 
-// The time to wait before retrying a failed PAC download. This is similar to Chrome's delay:
-// https://cs.chromium.org/chromium/src/net/proxy_resolution/proxy_resolution_service.cc?l=96&rcl=3db5f65968c3ecab3932c1ff7367ad28834f9502
-const delayAfterFailedDownload = 2 * time.Second
-
 type pacFetcher struct {
 	pacurl     string
 	monitor    netMonitor
@@ -59,7 +55,7 @@ func (pf *pacFetcher) download() []byte {
 	resp, err := pf.client.Get(pf.pacurl)
 	if err != nil || resp.StatusCode != http.StatusOK {
 		log.Printf("Error downloading PAC file, retrying after 2 seconds: %q", err)
-		time.Sleep(delayAfterFailedDownload)
+		time.Sleep(2 * time.Second)
 		resp, err = pf.client.Get(pf.pacurl)
 		if err != nil {
 			log.Printf("Error downloading PAC file, giving up: %q", err)

--- a/pacfetcher.go
+++ b/pacfetcher.go
@@ -54,8 +54,13 @@ func (pf *pacFetcher) download() []byte {
 	pf.connected = false
 	resp, err := pf.client.Get(pf.pacurl)
 	if err != nil {
-		log.Printf("Error downloading PAC file: %q", err)
-		return nil
+		log.Printf("Error downloading PAC file, retrying after 2 seconds: %q", err)
+		time.Sleep(2 * time.Second)
+		resp, err = pf.client.Get(pf.pacurl)
+		if err != nil {
+			log.Printf("Error downloading PAC file, giving up: %q", err)
+			return nil
+		}
 	}
 	defer resp.Body.Close()
 	log.Printf("GET %q returned %q", pf.pacurl, resp.Status)

--- a/pacfetcher_test.go
+++ b/pacfetcher_test.go
@@ -18,6 +18,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func init() {
+	// Set the retry delay to zero, so that it doesn't delay unit tests.
+	delayAfterFailedDownload = 0
+}
+
 func pacjsHandler(pacjs string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) { w.Write([]byte(pacjs)) }
 }


### PR DESCRIPTION
I can't think of a better way to fix issue #8. This should work around it in most, if not all, cases.