### PR TITLE
Introduce a `transport` type to write HTTP requests to a `net.Conn`

### DIFF
--- a/authenticator.go
+++ b/authenticator.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Alpaca Authors
+// Copyright 2019, 2021 The Alpaca Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,10 +15,8 @@
 package main
 
 import (
-	"bufio"
 	"encoding/base64"
 	"log"
-	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -28,47 +26,6 @@ import (
 
 type authenticator struct {
 	domain, username, password string
-}
-
-func (a authenticator) connect(req *http.Request, conn net.Conn, rd *bufio.Reader) (*http.Response, error) {
-	hostname, _ := os.Hostname() // in case of error, just use the zero value ("") as hostname
-	negotiate, err := ntlmssp.NewNegotiateMessage(a.domain, hostname)
-	if err != nil {
-		log.Printf("Error creating NTLM Type 1 (Negotiate) message: %v", err)
-		return nil, err
-	}
-	req.Header.Set("Proxy-Authorization", "NTLM "+base64.StdEncoding.EncodeToString(negotiate))
-	if err := req.Write(conn); err != nil {
-		log.Printf("Error sending NTLM Type 1 (Negotiate) request: %v", err)
-		return nil, err
-	}
-	resp, err := http.ReadResponse(rd, req)
-	if err != nil {
-		log.Printf("Error receiving NTLM Type 2 (Challenge) response: %v", err)
-		return nil, err
-	} else if resp.StatusCode != http.StatusProxyAuthRequired {
-		log.Printf("Expected response with status 407, got %s", resp.Status)
-		return resp, nil
-	}
-	defer resp.Body.Close()
-	challenge, err := base64.StdEncoding.DecodeString(
-		strings.TrimPrefix(resp.Header.Get("Proxy-Authenticate"), "NTLM "))
-	if err != nil {
-		log.Printf("Error decoding NTLM Type 2 (Challenge) message: %v", err)
-		return nil, err
-	}
-	authenticate, err := ntlmssp.ProcessChallenge(challenge, a.username, a.password)
-	if err != nil {
-		log.Printf("Error processing NTLM Type 2 (Challenge) message: %v", err)
-		return nil, err
-	}
-	req.Header.Set("Proxy-Authorization",
-		"NTLM "+base64.StdEncoding.EncodeToString(authenticate))
-	if err := req.Write(conn); err != nil {
-		log.Printf("Error sending NTLM Type 3 (Authenticate) request: %v", err)
-		return nil, err
-	}
-	return http.ReadResponse(rd, req)
 }
 
 func (a authenticator) do(req *http.Request, rt http.RoundTripper) (*http.Response, error) {

--- a/transport.go
+++ b/transport.go
@@ -1,0 +1,72 @@
+// Copyright 2021 The Alpaca Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bufio"
+	"errors"
+	"net"
+	"net/http"
+)
+
+// transport creates and manages the lifetime of a net.Conn. Between the time that a remote server
+// is dialled, and the connection hijacked or closed, a client can send HTTP requests using the
+// RoundTrip method (rather than writing requests and reading responses on the net.Conn).
+type transport struct {
+	conn   net.Conn
+	reader *bufio.Reader
+}
+
+func (t *transport) dial(network, address string) error {
+	if err := t.Close(); err != nil {
+		return err
+	}
+	conn, err := net.Dial(network, address)
+	if err != nil {
+		return err
+	}
+	t.conn = conn
+	t.reader = bufio.NewReader(conn)
+	return nil
+}
+
+func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.conn == nil {
+		return nil, errors.New("no connection, can't send request")
+	}
+	if err := req.Write(t.conn); err != nil {
+		return nil, err
+	}
+	return http.ReadResponse(t.reader, req)
+}
+
+func (t *transport) hijack() net.Conn {
+	defer func() {
+		t.conn = nil
+		t.reader = nil
+	}()
+	return t.conn
+}
+
+func (t *transport) Close() error {
+	if t.conn == nil {
+		return nil
+	}
+	defer func() {
+		t.conn = nil
+		t.reader = nil
+	}()
+	return t.conn.Close()
+}

--- a/transport_test.go
+++ b/transport_test.go
@@ -1,0 +1,85 @@
+// Copyright 2021 The Alpaca Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bufio"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransport(t *testing.T) {
+	handler := func(w http.ResponseWriter, req *http.Request) {
+		w.Write([]byte("It works!"))
+	}
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	defer server.Close()
+	var tr transport
+	require.NoError(t, tr.dial("tcp", server.Listener.Addr().String()))
+	defer tr.Close()
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	t.Run("RoundTrip", func(t *testing.T) {
+		resp, err := tr.RoundTrip(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		body, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Equal(t, "It works!", string(body))
+	})
+
+	t.Run("Hijack", func(t *testing.T) {
+		conn := tr.hijack()
+		defer conn.Close()
+		require.NoError(t, req.Write(conn))
+		resp, err := http.ReadResponse(bufio.NewReader(conn), req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		body, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Equal(t, "It works!", string(body))
+		assert.NoError(t, tr.Close())
+	})
+}
+
+func TestTransportErrors(t *testing.T) {
+	var tr transport
+	req, err := http.NewRequest(http.MethodGet, "http://alpaca.test", nil)
+	require.NoError(t, err)
+
+	t.Run("NotConnected", func (t *testing.T) {
+		_, err = tr.RoundTrip(req)
+		assert.Error(t, err)
+	})
+
+	t.Run("Closed", func (t *testing.T) {
+		require.NoError(t, tr.Close())
+		_, err = tr.RoundTrip(req)
+		assert.Error(t, err)
+	})
+
+	t.Run("CloseTwice", func (t *testing.T) {
+		assert.NoError(t, tr.Close())
+		assert.NoError(t, tr.Close())
+	})
+}


### PR DESCRIPTION
The purpose of this change is to reduce code duplication in
`authenticator.go`. Previously, we needed to have two separate
implementations of the NTLM handshake: one for CONNECT requests (which
are written directly to a `net.Conn`) and another for all other requests
(which are sent via an `http.Transport`). Now that we only need one
(written against any `http.RoundTripper`), it will be simpler to
implement additional authentication protocols in the future, such as
Kerberos.