### PR TITLE
Rename exported structs and functions

### DIFF
--- a/authenticator.go
+++ b/authenticator.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Alpaca Authors
+// Copyright 2019, 2021 The Alpaca Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,10 +15,8 @@
 package main
 
 import (
-	"bufio"
 	"encoding/base64"
 	"log"
-	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -28,47 +26,6 @@ import (
 
 type authenticator struct {
 	domain, username, password string
-}
-
-func (a authenticator) connect(req *http.Request, conn net.Conn, rd *bufio.Reader) (*http.Response, error) {
-	hostname, _ := os.Hostname() // in case of error, just use the zero value ("") as hostname
-	negotiate, err := ntlmssp.NewNegotiateMessage(a.domain, hostname)
-	if err != nil {
-		log.Printf("Error creating NTLM Type 1 (Negotiate) message: %v", err)
-		return nil, err
-	}
-	req.Header.Set("Proxy-Authorization", "NTLM "+base64.StdEncoding.EncodeToString(negotiate))
-	if err := req.Write(conn); err != nil {
-		log.Printf("Error sending NTLM Type 1 (Negotiate) request: %v", err)
-		return nil, err
-	}
-	resp, err := http.ReadResponse(rd, req)
-	if err != nil {
-		log.Printf("Error receiving NTLM Type 2 (Challenge) response: %v", err)
-		return nil, err
-	} else if resp.StatusCode != http.StatusProxyAuthRequired {
-		log.Printf("Expected response with status 407, got %s", resp.Status)
-		return resp, nil
-	}
-	defer resp.Body.Close()
-	challenge, err := base64.StdEncoding.DecodeString(
-		strings.TrimPrefix(resp.Header.Get("Proxy-Authenticate"), "NTLM "))
-	if err != nil {
-		log.Printf("Error decoding NTLM Type 2 (Challenge) message: %v", err)
-		return nil, err
-	}
-	authenticate, err := ntlmssp.ProcessChallenge(challenge, a.username, a.password)
-	if err != nil {
-		log.Printf("Error processing NTLM Type 2 (Challenge) message: %v", err)
-		return nil, err
-	}
-	req.Header.Set("Proxy-Authorization",
-		"NTLM "+base64.StdEncoding.EncodeToString(authenticate))
-	if err := req.Write(conn); err != nil {
-		log.Printf("Error sending NTLM Type 3 (Authenticate) request: %v", err)
-		return nil, err
-	}
-	return http.ReadResponse(rd, req)
 }
 
 func (a authenticator) do(req *http.Request, rt http.RoundTripper) (*http.Response, error) {

--- a/blocklist.go
+++ b/blocklist.go
@@ -1,0 +1,81 @@
+// Copyright 2021 The Alpaca Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// This duration was chosen to match Chrome's behaviour (see "Evaluating proxy lists" in
+// https://crsrc.org/net/docs/proxy.md).
+const maxAge = 5 * time.Minute
+
+type blocklist struct {
+	entries []string             // Slice of entries, ordered by expiry time
+	expiry  map[string]time.Time // Map containing the expiry time for each entry
+	now     func() time.Time
+	mux     sync.Mutex
+}
+
+func newBlocklist() *blocklist {
+	return &blocklist{
+		entries: []string{},
+		expiry:  make(map[string]time.Time),
+		now:     time.Now,
+	}
+}
+
+func (b *blocklist) add(entry string) {
+	b.mux.Lock()
+	defer b.mux.Unlock()
+	b.sweep()
+	if _, ok := b.expiry[entry]; ok {
+		// Ignore duplicate entries. An entry can only have a single expiry time, so it
+		// shouldn't be added to the `entries` slice twice. Otherwise we'll have problems
+		// deleting it later.
+		return
+	}
+	b.expiry[entry] = b.now().Add(maxAge)
+	b.entries = append(b.entries, entry)
+}
+
+func (b *blocklist) contains(entry string) bool {
+	b.mux.Lock()
+	defer b.mux.Unlock()
+	b.sweep()
+	_, ok := b.expiry[entry]
+	return ok
+}
+
+func (b *blocklist) sweep() {
+	// Delete any stale entries from both the slice and the map. This function is *not*
+	// reentrant; `mux` should be locked before calling this function!
+	count := 0
+	for _, entry := range b.entries {
+		expiry, ok := b.expiry[entry]
+		if !ok {
+			// This should never happen.
+			panic(fmt.Sprintf("blocklist contains entry %q without expiry time", entry))
+		}
+		if b.now().Before(expiry) {
+			break
+		}
+		delete(b.expiry, entry)
+		count++
+	}
+	b.entries = b.entries[count:]
+}

--- a/blocklist_test.go
+++ b/blocklist_test.go
@@ -1,0 +1,58 @@
+// Copyright 2021 The Alpaca Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBlocklistExpiry(t *testing.T) {
+	b := newBlocklist()
+	var now time.Time
+	b.now = func() time.Time { return now }
+
+	b.add("foo")
+	assert.True(t, b.contains("foo"))
+	assert.False(t, b.contains("bar"))
+
+	now = now.Add(3 * time.Minute)
+	b.add("bar")
+	assert.True(t, b.contains("foo"))
+	assert.True(t, b.contains("bar"))
+
+	now = now.Add(3 * time.Minute)
+	assert.False(t, b.contains("foo"))
+	assert.True(t, b.contains("bar"))
+
+	now = now.Add(3 * time.Minute)
+	assert.False(t, b.contains("foo"))
+	assert.False(t, b.contains("bar"))
+}
+
+func TestBlocklistDuplicateEntry(t *testing.T) {
+	b := newBlocklist()
+	var now time.Time
+	b.now = func() time.Time { return now }
+	b.add("foo")
+	now = now.Add(3*time.Minute)
+	b.add("foo")
+	now = now.Add(3*time.Minute)
+	b.contains("foo")
+	now = now.Add(3*time.Minute)
+	b.contains("foo")
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/samuong/alpaca
 
-go 1.12
+go 1.13
 
 require (
 	github.com/Azure/go-ntlmssp v0.0.0-20180810175552-4a21cbd618b4

--- a/main.go
+++ b/main.go
@@ -72,7 +72,7 @@ func main() {
 
 	pacWrapper := NewPACWrapper(PACData{Port: *port})
 	proxyFinder := NewProxyFinder(pacURL, pacWrapper)
-	proxyHandler := NewProxyHandler(proxyFinder.findProxyForRequest, a)
+	proxyHandler := NewProxyHandler(proxyFinder.findProxyForRequest, a, proxyFinder.blockProxy)
 	mux := http.NewServeMux()
 	pacWrapper.SetupHandlers(mux)
 

--- a/main.go
+++ b/main.go
@@ -70,17 +70,17 @@ func main() {
 		}
 	}
 
-	pacWrapper := NewPACWrapper(PACData{Port: *port})
-	proxyFinder := NewProxyFinder(pacURL, pacWrapper)
-	proxyHandler := NewProxyHandler(proxyFinder.findProxyForRequest, a, proxyFinder.blockProxy)
+	pacWrapper := newPACWrapper(*port)
+	proxyFinder := newProxyFinder(pacURL, pacWrapper)
+	proxyHandler := newProxyHandler(proxyFinder.findProxyForRequest, a, proxyFinder.blockProxy)
 	mux := http.NewServeMux()
-	pacWrapper.SetupHandlers(mux)
+	pacWrapper.setupHandlers(mux)
 
 	// build the handler by wrapping middleware upon middleware
 	var handler http.Handler = mux
 	handler = RequestLogger(handler)
-	handler = proxyHandler.WrapHandler(handler)
-	handler = proxyFinder.WrapHandler(handler)
+	handler = proxyHandler.wrapHandler(handler)
+	handler = proxyFinder.wrapHandler(handler)
 	handler = AddContextID(handler)
 
 	s := &http.Server{

--- a/pacrunner.go
+++ b/pacrunner.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Alpaca Authors
+// Copyright 2019, 2021 The Alpaca Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,12 +29,12 @@ import (
 
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Proxy_servers_and_tunneling/Proxy_Auto-Configuration_(PAC)_file
 
-type PACRunner struct {
+type pacRunner struct {
 	vm *otto.Otto
 	sync.Mutex
 }
 
-func (pr *PACRunner) Update(pacjs []byte) error {
+func (pr *pacRunner) update(pacjs []byte) error {
 	vm := otto.New()
 	var err error
 	set := func(name string, handler func(otto.FunctionCall) otto.Value) {
@@ -73,7 +73,7 @@ func (pr *PACRunner) Update(pacjs []byte) error {
 	return nil
 }
 
-func (pr *PACRunner) FindProxyForURL(u *url.URL) (string, error) {
+func (pr *pacRunner) findProxyForURL(u *url.URL) (string, error) {
 	pr.Lock()
 	defer pr.Unlock()
 	if u.Scheme == "https" || u.Scheme == "wss" {

--- a/pacrunner_test.go
+++ b/pacrunner_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Alpaca Authors
+// Copyright 2019, 2021 The Alpaca Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,10 +27,10 @@ import (
 )
 
 func TestDirect(t *testing.T) {
-	var pr PACRunner
+	var pr pacRunner
 	pacjs := []byte(`function FindProxyForURL(url, host) { return "DIRECT" }`)
-	require.NoError(t, pr.Update(pacjs))
-	proxy, err := pr.FindProxyForURL(&url.URL{Scheme: "https", Host: "anz.com"})
+	require.NoError(t, pr.update(pacjs))
+	proxy, err := pr.findProxyForURL(&url.URL{Scheme: "https", Host: "anz.com"})
 	require.NoError(t, err)
 	assert.Equal(t, "DIRECT", proxy)
 }
@@ -45,13 +45,13 @@ func TestPathAndQueryStripping(t *testing.T) {
 		{"https with fragment", "https://anz.com/#fragment", "https://anz.com"},
 	}
 	for _, test := range tests {
-		var pr PACRunner
+		var pr pacRunner
 		pacjs := []byte("function FindProxyForURL(url, host) { return url }")
-		require.NoError(t, pr.Update(pacjs))
+		require.NoError(t, pr.update(pacjs))
 		t.Run(test.name, func(t *testing.T) {
 			u, err := url.Parse(test.input)
 			require.NoError(t, err)
-			proxy, err := pr.FindProxyForURL(u)
+			proxy, err := pr.findProxyForURL(u)
 			require.NoError(t, err)
 			assert.Equal(t, test.expected, proxy)
 		})

--- a/pacwrapper_test.go
+++ b/pacwrapper_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Alpaca Authors
+// Copyright 2019, 2021 The Alpaca Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,25 +25,25 @@ import (
 )
 
 func TestWrapPAC(t *testing.T) {
-	pw := NewPACWrapper(PACData{Port: 1234})
+	pw := newPACWrapper(1234)
 	pac := `function FindProxyForURL(url, host) { return "DIRECT" }`
-	pw.Wrap([]byte(pac))
+	pw.wrap([]byte(pac))
 	assert.Contains(t, pw.alpacaPAC, pac)
 	assert.Contains(t, pw.alpacaPAC, `"DIRECT" : "PROXY localhost:1234"`)
 }
 
 func TestWrapEmptyPAC(t *testing.T) {
-	pw := NewPACWrapper(PACData{Port: 1234})
-	pw.Wrap(nil)
+	pw := newPACWrapper(1234)
+	pw.wrap(nil)
 	assert.Contains(t, pw.alpacaPAC, `return "DIRECT"`)
 }
 
 func TestPACServe(t *testing.T) {
-	pw := NewPACWrapper(PACData{Port: 1234})
+	pw := newPACWrapper(1234)
 	pac := `function FindProxyForURL(url, host) { return "DIRECT" }`
-	pw.Wrap([]byte(pac))
+	pw.wrap([]byte(pac))
 	mux := http.NewServeMux()
-	pw.SetupHandlers(mux)
+	pw.setupHandlers(mux)
 	server := httptest.NewServer(mux)
 	defer server.Close()
 

--- a/proxy.go
+++ b/proxy.go
@@ -16,6 +16,8 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -31,12 +33,13 @@ import (
 type ProxyHandler struct {
 	transport *http.Transport
 	auth      *authenticator
+	block     func(string)
 }
 
 type proxyFunc func(*http.Request) (*url.URL, error)
 
-func NewProxyHandler(proxy proxyFunc, auth *authenticator) ProxyHandler {
-	return ProxyHandler{&http.Transport{Proxy: proxy}, auth}
+func NewProxyHandler(proxy proxyFunc, auth *authenticator, block func(string)) ProxyHandler {
+	return ProxyHandler{&http.Transport{Proxy: proxy}, auth, block}
 }
 
 func (ph ProxyHandler) WrapHandler(next http.Handler) http.Handler {
@@ -79,6 +82,10 @@ func (ph ProxyHandler) handleConnect(w http.ResponseWriter, req *http.Request) {
 		server, err = net.Dial("tcp", req.Host)
 	} else {
 		server, err = connectViaProxy(req, u.Host, ph.auth)
+		var dialErr *dialError
+		if errors.As(err, &dialErr) {
+			ph.block(u.Host)
+		}
 	}
 	if err != nil {
 		w.WriteHeader(http.StatusBadGateway)
@@ -127,7 +134,7 @@ func connectViaProxy(req *http.Request, proxy string, auth *authenticator) (net.
 	id := req.Context().Value(contextKeyID)
 	var tr transport
 	defer tr.Close()
-	if err := tr.dial("tcp", proxy) ; err != nil {
+	if err := tr.dial("tcp", proxy); err != nil {
 		log.Printf("[%d] Error dialling %s: %v", id, proxy, err)
 		return nil, err
 	}
@@ -167,6 +174,11 @@ func (ph ProxyHandler) proxyRequest(w http.ResponseWriter, req *http.Request, au
 	req.Body = ioutil.NopCloser(rd)
 	resp, err := ph.transport.RoundTrip(req)
 	if err != nil {
+		var dialErr *dialError
+		if errors.As(err, &dialErr) && dialErr.address != req.Host {
+			// Failed to dial the proxy; add it to the bad list.
+			ph.block(dialErr.address)
+		}
 		log.Printf("[%d] Error forwarding request: %v", id, err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
@@ -238,4 +250,25 @@ func copyResponseHeaders(w http.ResponseWriter, resp *http.Response) {
 	w.Header().Del("Trailer")
 	w.Header().Del("Transfer-Encoding")
 	w.Header().Del("Upgrade")
+}
+
+type dialError struct {
+	network, address string
+	err              error
+}
+
+func (e *dialError) Error() string {
+	return fmt.Sprintf("error while dialing %q %q: %s", e.network, e.address, e.err.Error())
+}
+
+func (e *dialError) Unwrap() error {
+	return e.err
+}
+
+func dialContext(ignored context.Context, network, address string) (net.Conn, error) {
+	conn, err := net.Dial(network, address)
+	if err != nil {
+		return conn, &dialError{network, address, err}
+	}
+	return conn, nil
 }

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -54,13 +54,17 @@ func (tp testProxy) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 }
 
 func newDirectProxy() ProxyHandler {
-	return NewProxyHandler(func(r *http.Request) (*url.URL, error) { return nil, nil }, nil)
+	return NewProxyHandler(
+		func(r *http.Request) (*url.URL, error) { return nil, nil },
+		nil,
+		func(string) {},
+	)
 }
 
 func newChildProxy(parent *httptest.Server) ProxyHandler {
 	return NewProxyHandler(func(r *http.Request) (*url.URL, error) {
 		return &url.URL{Host: parent.Listener.Addr().String()}, nil
-	}, nil)
+	}, nil, func(string) {})
 }
 
 func proxyServer(t *testing.T, proxy *httptest.Server) proxyFunc {

--- a/proxyfinder.go
+++ b/proxyfinder.go
@@ -26,29 +26,29 @@ import (
 
 var errNoProxiesAvailable = errors.New("no proxies available")
 
-type ProxyFinder struct {
-	runner  *PACRunner
+type proxyFinder struct {
+	runner  *pacRunner
 	fetcher *pacFetcher
-	wrapper *PACWrapper
+	wrapper *pacWrapper
 	blocked *blocklist
 	sync.Mutex
 }
 
-func NewProxyFinder(pacurl string, wrapper *PACWrapper) *ProxyFinder {
-	pf := &ProxyFinder{wrapper: wrapper, blocked: newBlocklist()}
+func newProxyFinder(pacurl string, wrapper *pacWrapper) *proxyFinder {
+	pf := &proxyFinder{wrapper: wrapper, blocked: newBlocklist()}
 	if len(pacurl) == 0 {
 		log.Println("No PAC URL specified or detected; all requests will be made directly")
 	} else if _, err := url.Parse(pacurl); err != nil {
 		log.Fatalf("Couldn't find a valid PAC URL: %v", pacurl)
 	} else {
-		pf.runner = new(PACRunner)
+		pf.runner = new(pacRunner)
 		pf.fetcher = newPACFetcher(pacurl)
 		pf.checkForUpdates()
 	}
 	return pf
 }
 
-func (pf *ProxyFinder) WrapHandler(next http.Handler) http.Handler {
+func (pf *proxyFinder) wrapHandler(next http.Handler) http.Handler {
 	// If we don't have a fetcher, don't wrap the handler as there's nothing to do.
 	if pf.fetcher == nil {
 		return next
@@ -59,7 +59,7 @@ func (pf *ProxyFinder) WrapHandler(next http.Handler) http.Handler {
 	})
 }
 
-func (pf *ProxyFinder) checkForUpdates() {
+func (pf *proxyFinder) checkForUpdates() {
 	pf.Lock()
 	defer pf.Unlock()
 	var pacjs []byte
@@ -67,19 +67,19 @@ func (pf *ProxyFinder) checkForUpdates() {
 	if pacjs == nil {
 		if !pf.fetcher.isConnected() {
 			pf.blocked = newBlocklist()
-			pf.wrapper.Wrap(nil)
+			pf.wrapper.wrap(nil)
 		}
 		return
 	}
 	pf.blocked = newBlocklist()
-	if err := pf.runner.Update(pacjs); err != nil {
+	if err := pf.runner.update(pacjs); err != nil {
 		log.Printf("Error running PAC JS: %q", err)
 	} else {
-		pf.wrapper.Wrap(pacjs)
+		pf.wrapper.wrap(pacjs)
 	}
 }
 
-func (pf *ProxyFinder) findProxyForRequest(req *http.Request) (*url.URL, error) {
+func (pf *proxyFinder) findProxyForRequest(req *http.Request) (*url.URL, error) {
 	id := req.Context().Value(contextKeyID)
 	if pf.fetcher == nil {
 		log.Printf(`[%d] %s %s via "DIRECT"`, id, req.Method, req.URL)
@@ -89,7 +89,7 @@ func (pf *ProxyFinder) findProxyForRequest(req *http.Request) (*url.URL, error) 
 		log.Printf(`[%d] %s %s via "DIRECT" (not connected)`, id, req.Method, req.URL)
 		return nil, nil
 	}
-	str, err := pf.runner.FindProxyForURL(req.URL)
+	str, err := pf.runner.findProxyForURL(req.URL)
 	if err != nil {
 		return nil, err
 	}
@@ -119,6 +119,6 @@ func (pf *ProxyFinder) findProxyForRequest(req *http.Request) (*url.URL, error) 
 	return nil, errNoProxiesAvailable
 }
 
-func (pf *ProxyFinder) blockProxy(proxy string) {
+func (pf *proxyFinder) blockProxy(proxy string) {
 	pf.blocked.add(proxy)
 }

--- a/proxyfinder.go
+++ b/proxyfinder.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Alpaca Authors
+// Copyright 2019, 2021 The Alpaca Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@ package main
 
 import (
 	"errors"
-	"fmt"
 	"log"
 	"net"
 	"net/http"
@@ -25,15 +24,18 @@ import (
 	"sync"
 )
 
+var errNoProxiesAvailable = errors.New("no proxies available")
+
 type ProxyFinder struct {
 	runner  *PACRunner
 	fetcher *pacFetcher
 	wrapper *PACWrapper
+	blocked *blocklist
 	sync.Mutex
 }
 
 func NewProxyFinder(pacurl string, wrapper *PACWrapper) *ProxyFinder {
-	pf := &ProxyFinder{wrapper: wrapper}
+	pf := &ProxyFinder{wrapper: wrapper, blocked: newBlocklist()}
 	if len(pacurl) == 0 {
 		log.Println("No PAC URL specified or detected; all requests will be made directly")
 	} else if _, err := url.Parse(pacurl); err != nil {
@@ -64,10 +66,12 @@ func (pf *ProxyFinder) checkForUpdates() {
 	pacjs = pf.fetcher.download()
 	if pacjs == nil {
 		if !pf.fetcher.isConnected() {
+			pf.blocked = newBlocklist()
 			pf.wrapper.Wrap(nil)
 		}
 		return
 	}
+	pf.blocked = newBlocklist()
 	if err := pf.runner.Update(pacjs); err != nil {
 		log.Printf("Error running PAC JS: %q", err)
 	} else {
@@ -85,34 +89,36 @@ func (pf *ProxyFinder) findProxyForRequest(req *http.Request) (*url.URL, error) 
 		log.Printf(`[%d] %s %s via "DIRECT" (not connected)`, id, req.Method, req.URL)
 		return nil, nil
 	}
-	s, err := pf.runner.FindProxyForURL(req.URL)
+	str, err := pf.runner.FindProxyForURL(req.URL)
 	if err != nil {
 		return nil, err
 	}
-	log.Printf("[%d] %s %s via %q", id, req.Method, req.URL, s)
-	ss := strings.Split(s, ";")
-	if len(ss) > 1 {
-		log.Printf("[%d] Warning: ignoring all but first proxy in %q", id, s)
-	}
-	trimmed := strings.TrimSpace(ss[0])
-	if trimmed == "DIRECT" {
-		return nil, nil
-	}
-	var host string
-	n, err := fmt.Sscanf(trimmed, "PROXY %s", &host)
-	if err == nil && n == 1 {
-		// The specified proxy should contain both a host and a port, but if for some reason
-		// it doesn't, assume port 80. This needs to be made explicit, as it eventually gets
-		// passed to net.Dial, which also requires a port.
-		proxy := &url.URL{Host: host}
-		if proxy.Port() == "" {
-			proxy.Host = net.JoinHostPort(host, "80")
+	arr := strings.Split(str, ";")
+	for _, elem := range arr {
+		fields := strings.Fields(strings.TrimSpace(elem))
+		if len(fields) == 1 && fields[0] == "DIRECT" {
+			log.Printf("[%d] %s %s via %q", id, req.Method, req.URL, elem)
+			return nil, nil
+		} else if len(fields) == 2 && fields[0] == "PROXY" {
+			// The specified proxy should contain both a host and a port, but if for
+			// some reason it doesn't, assume port 80. This needs to be made explicit,
+			// as it eventually gets passed to net.Dial, which also requires a port.
+			proxy := &url.URL{Host: fields[1]}
+			if proxy.Port() == "" {
+				proxy.Host = net.JoinHostPort(proxy.Host, "80")
+			}
+			if pf.blocked.contains(proxy.Host) {
+				log.Printf("[%d] Skipping bad proxy: %q", id, proxy.Host)
+				continue
+			}
+			log.Printf("[%d] %s %s via %q", id, req.Method, req.URL, elem)
+			return proxy, nil
 		}
-		return proxy, nil
+		log.Printf("[%d] Coudln't parse proxy: %q", id, elem)
 	}
-	if strings.HasPrefix(trimmed, "SOCKS ") {
-		return nil, errors.New("Alpaca does not yet support SOCKS proxies")
-	} else {
-		return nil, errors.New("Couldn't parse PAC response")
-	}
+	return nil, errNoProxiesAvailable
+}
+
+func (pf *ProxyFinder) blockProxy(proxy string) {
+	pf.blocked.add(proxy)
 }

--- a/proxyfinder_test.go
+++ b/proxyfinder_test.go
@@ -45,8 +45,8 @@ func TestFindProxyForRequest(t *testing.T) {
 			js := fmt.Sprintf("function FindProxyForURL(url, host) { %s }", test.body)
 			server := httptest.NewServer(http.HandlerFunc(pacjsHandler(js)))
 			defer server.Close()
-			pw := NewPACWrapper(PACData{Port: 1})
-			pf := NewProxyFinder(server.URL, pw)
+			pw := newPACWrapper(1)
+			pf := newProxyFinder(server.URL, pw)
 			req := httptest.NewRequest(http.MethodGet, "https://www.test", nil)
 			ctx := context.WithValue(req.Context(), contextKeyID, i)
 			req = req.WithContext(ctx)
@@ -68,8 +68,8 @@ func TestFindProxyForRequest(t *testing.T) {
 
 func TestFallbackToDirectWhenNotConnected(t *testing.T) {
 	url := "http://pacserver.invalid/nonexistent.pac"
-	pw := NewPACWrapper(PACData{Port: 1})
-	pf := NewProxyFinder(url, pw)
+	pw := newPACWrapper(1)
+	pf := newProxyFinder(url, pw)
 	req := httptest.NewRequest(http.MethodGet, "http://www.test", nil)
 	proxy, err := pf.findProxyForRequest(req)
 	require.NoError(t, err)
@@ -78,8 +78,8 @@ func TestFallbackToDirectWhenNotConnected(t *testing.T) {
 
 func TestFallbackToDirectWhenNoPACURL(t *testing.T) {
 	url := ""
-	pw := NewPACWrapper(PACData{Port: 1})
-	pf := NewProxyFinder(url, pw)
+	pw := newPACWrapper(1)
+	pf := newProxyFinder(url, pw)
 	req := httptest.NewRequest(http.MethodGet, "http://www.test", nil)
 	proxy, err := pf.findProxyForRequest(req)
 	require.NoError(t, err)
@@ -90,8 +90,8 @@ func TestSkipBadProxies(t *testing.T) {
 	js := `function FindProxyForURL(url, host) { return "PROXY primary:80; PROXY backup:80" }`
 	server := httptest.NewServer(http.HandlerFunc(pacjsHandler(js)))
 	defer server.Close()
-	pw := NewPACWrapper(PACData{Port: 1})
-	pf := NewProxyFinder(server.URL, pw)
+	pw := newPACWrapper(1)
+	pf := newProxyFinder(server.URL, pw)
 	req := httptest.NewRequest(http.MethodGet, "https://www.test", nil)
 	ctx := context.WithValue(req.Context(), contextKeyID, 0)
 	req = req.WithContext(ctx)

--- a/proxyfinder_test.go
+++ b/proxyfinder_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Alpaca Authors
+// Copyright 2019, 2021 The Alpaca Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -84,4 +84,25 @@ func TestFallbackToDirectWhenNoPACURL(t *testing.T) {
 	proxy, err := pf.findProxyForRequest(req)
 	require.NoError(t, err)
 	assert.Nil(t, proxy)
+}
+
+func TestSkipBadProxies(t *testing.T) {
+	js := `function FindProxyForURL(url, host) { return "PROXY primary:80; PROXY backup:80" }`
+	server := httptest.NewServer(http.HandlerFunc(pacjsHandler(js)))
+	defer server.Close()
+	pw := NewPACWrapper(PACData{Port: 1})
+	pf := NewProxyFinder(server.URL, pw)
+	req := httptest.NewRequest(http.MethodGet, "https://www.test", nil)
+	ctx := context.WithValue(req.Context(), contextKeyID, 0)
+	req = req.WithContext(ctx)
+	proxy, err := pf.findProxyForRequest(req)
+	require.NoError(t, err)
+	assert.Equal(t, "primary:80", proxy.Host)
+	pf.blocked.add("primary:80")
+	proxy, err = pf.findProxyForRequest(req)
+	require.NoError(t, err)
+	assert.Equal(t, "backup:80", proxy.Host)
+	pf.blocked.add("backup:80")
+	_, err = pf.findProxyForRequest(req)
+	assert.Error(t, err)
 }

--- a/transport.go
+++ b/transport.go
@@ -1,0 +1,72 @@
+// Copyright 2021 The Alpaca Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bufio"
+	"errors"
+	"net"
+	"net/http"
+)
+
+// transport creates and manages the lifetime of a net.Conn. Between the time that a remote server
+// is dialled, and the connection hijacked or closed, a client can send HTTP requests using the
+// RoundTrip method (rather than writing requests and reading responses on the net.Conn).
+type transport struct {
+	conn   net.Conn
+	reader *bufio.Reader
+}
+
+func (t *transport) dial(network, address string) error {
+	if err := t.Close(); err != nil {
+		return err
+	}
+	conn, err := net.Dial(network, address)
+	if err != nil {
+		return err
+	}
+	t.conn = conn
+	t.reader = bufio.NewReader(conn)
+	return nil
+}
+
+func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.conn == nil {
+		return nil, errors.New("no connection, can't send request")
+	}
+	if err := req.Write(t.conn); err != nil {
+		return nil, err
+	}
+	return http.ReadResponse(t.reader, req)
+}
+
+func (t *transport) hijack() net.Conn {
+	defer func() {
+		t.conn = nil
+		t.reader = nil
+	}()
+	return t.conn
+}
+
+func (t *transport) Close() error {
+	if t.conn == nil {
+		return nil
+	}
+	defer func() {
+		t.conn = nil
+		t.reader = nil
+	}()
+	return t.conn.Close()
+}

--- a/transport_test.go
+++ b/transport_test.go
@@ -1,0 +1,85 @@
+// Copyright 2021 The Alpaca Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bufio"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransport(t *testing.T) {
+	handler := func(w http.ResponseWriter, req *http.Request) {
+		w.Write([]byte("It works!"))
+	}
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	defer server.Close()
+	var tr transport
+	require.NoError(t, tr.dial("tcp", server.Listener.Addr().String()))
+	defer tr.Close()
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+
+	t.Run("RoundTrip", func(t *testing.T) {
+		resp, err := tr.RoundTrip(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		body, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Equal(t, "It works!", string(body))
+	})
+
+	t.Run("Hijack", func(t *testing.T) {
+		conn := tr.hijack()
+		defer conn.Close()
+		require.NoError(t, req.Write(conn))
+		resp, err := http.ReadResponse(bufio.NewReader(conn), req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		body, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Equal(t, "It works!", string(body))
+		assert.NoError(t, tr.Close())
+	})
+}
+
+func TestTransportErrors(t *testing.T) {
+	var tr transport
+	req, err := http.NewRequest(http.MethodGet, "http://alpaca.test", nil)
+	require.NoError(t, err)
+
+	t.Run("NotConnected", func (t *testing.T) {
+		_, err = tr.RoundTrip(req)
+		assert.Error(t, err)
+	})
+
+	t.Run("Closed", func (t *testing.T) {
+		require.NoError(t, tr.Close())
+		_, err = tr.RoundTrip(req)
+		assert.Error(t, err)
+	})
+
+	t.Run("CloseTwice", func (t *testing.T) {
+		assert.NoError(t, tr.Close())
+		assert.NoError(t, tr.Close())
+	})
+}


### PR DESCRIPTION
This reduces the "public API" of the `main` package to nothing. The next
release of Alpaca will be v2.0.0, and any exported names will be made
available in sub-packages with a minor version bump.