### PR TITLE
Run lint/release jobs on Ubuntu, and Windows build/tests on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   format:
     strategy:
       matrix: 
-        os: [ 'macos-latest' ]
+        os: [ 'ubuntu-latest' ]
         go: [ '1.16' ]
 
     runs-on: ${{ matrix.os }}
@@ -35,7 +35,7 @@ jobs:
   test:
     strategy:
       matrix: 
-        os: [ 'macos-latest', 'ubuntu-latest' ]
+        os: [ 'macos-latest', 'ubuntu-latest', 'windows-latest' ]
         go: [ '1.16' ]
 
     runs-on: ${{ matrix.os }}
@@ -65,7 +65,7 @@ jobs:
           - os: 'ubuntu-latest'
             goos: 'linux'
             goarch: 'amd64'
-          - os: 'ubuntu-latest'
+          - os: 'windows-latest'
             goos: 'windows'
             goarch: 'amd64'
         go: [ '1.16' ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/create-release@v1
@@ -41,7 +41,7 @@ jobs:
           - os: 'ubuntu-latest'
             goos: 'linux'
             goarch: 'amd64'
-          - os: 'ubuntu-latest'
+          - os: 'windows-latest'
             goos: 'windows'
             goarch: 'amd64'
         go: [ '1.16' ]

--- a/pacfetcher.go
+++ b/pacfetcher.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Alpaca Authors
+// Copyright 2019, 2021 The Alpaca Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -50,7 +51,11 @@ func newPACFetcher(pacurl string) *pacFetcher {
 	client := &http.Client{Timeout: 30 * time.Second}
 	if strings.HasPrefix(pacurl, "file:") {
 		log.Printf("Warning: Alpaca supports file:// PAC URLs, but Windows and macOS don't")
-		client.Transport = http.NewFileTransport(http.Dir("/"))
+		if runtime.GOOS == "windows" {
+			client.Transport = http.NewFileTransport(http.Dir("C:"))
+		} else {
+			client.Transport = http.NewFileTransport(http.Dir("/"))
+		}
 	} else {
 		// The DefaultClient in net/http uses the proxy specified in the http(s)_proxy
 		// environment variable, which could be pointing at this instance of alpaca. When

--- a/pacfinder_darwin.go
+++ b/pacfinder_darwin.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Alpaca Authors
+// Copyright 2019, 2021 The Alpaca Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,24 +20,10 @@ import (
 	"io"
 	"log"
 	"os/exec"
-	"runtime"
 	"strings"
 )
 
 func findPACURL() (string, error) {
-	switch runtime.GOOS {
-	case "darwin":
-		return findPACURLForDarwin()
-	case "windows":
-		return findPACURLForWindows()
-	default:
-		// Hopefully Linux, FreeBSD, Solaris, etc. will have GNOME 3 installed...
-		// TODO: Figure out how to do this for KDE.
-		return findPACURLForGNOME()
-	}
-}
-
-func findPACURLForDarwin() (string, error) {
 	cmd := exec.Command("networksetup", "-listallnetworkservices")
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -100,18 +86,4 @@ func getAutoProxyURL(networkService string) (string, error) {
 		return strings.TrimSuffix(strings.TrimPrefix(line, "URL: "), "\n"), nil
 	}
 	return "", fmt.Errorf("No auto-proxy URL for network service %v", networkService)
-}
-
-func findPACURLForWindows() (string, error) {
-	// TODO: Implement this.
-	return "", nil
-}
-
-func findPACURLForGNOME() (string, error) {
-	cmd := exec.Command("gsettings", "get", "org.gnome.system.proxy", "autoconfig-url")
-	out, err := cmd.Output()
-	if err != nil {
-		return "", err
-	}
-	return strings.Trim(string(out), "'\n"), nil
 }

--- a/pacfinder_darwin_test.go
+++ b/pacfinder_darwin_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Alpaca Authors
+// Copyright 2019, 2021 The Alpaca Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFindPACURLForDarwin(t *testing.T) {
+func TestFindPACURL(t *testing.T) {
 	dir, err := ioutil.TempDir("", "alpaca")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
@@ -73,46 +73,18 @@ fi
 exit 0`
 	require.NoError(t, ioutil.WriteFile(tmpfn, []byte(mockcmd), 0700))
 
-	pacURL, err := findPACURLForDarwin()
+	pacURL, err := findPACURL()
 	require.NoError(t, err)
 	assert.Equal(t, "http://internal.anz.com/proxy.pac", pacURL)
 }
 
-func TestFindPACURLForDarwinWhenNetworkSetupIsntAvailable(t *testing.T) {
+func TestFindPACURLWhenNetworkSetupIsntAvailable(t *testing.T) {
 	dir, err := ioutil.TempDir("", "alpaca")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 	oldpath := os.Getenv("PATH")
 	defer require.NoError(t, os.Setenv("PATH", oldpath))
 	require.NoError(t, os.Setenv("PATH", dir))
-	_, err = findPACURLForDarwin()
-	require.NotNil(t, err)
-}
-
-func TestFindPACURLForGNOME(t *testing.T) {
-	dir, err := ioutil.TempDir("", "alpaca")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-	oldpath := os.Getenv("PATH")
-	defer require.NoError(t, os.Setenv("PATH", oldpath))
-
-	require.NoError(t, os.Setenv("PATH", dir))
-	tmpfn := filepath.Join(dir, "gsettings")
-	mockcmd := "#!/bin/sh\necho \\'http://internal.anz.com/proxy.pac\\'\n"
-	require.NoError(t, ioutil.WriteFile(tmpfn, []byte(mockcmd), 0700))
-
-	pacURL, err := findPACURLForGNOME()
-	require.NoError(t, err)
-	assert.Equal(t, "http://internal.anz.com/proxy.pac", pacURL)
-}
-
-func TestFindPACURLForGNOMEWhenGsettingsIsntAvailable(t *testing.T) {
-	dir, err := ioutil.TempDir("", "alpaca")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-	oldpath := os.Getenv("PATH")
-	defer require.NoError(t, os.Setenv("PATH", oldpath))
-	require.NoError(t, os.Setenv("PATH", dir))
-	_, err = findPACURLForGNOME()
+	_, err = findPACURL()
 	require.NotNil(t, err)
 }

--- a/pacfinder_unix.go
+++ b/pacfinder_unix.go
@@ -1,0 +1,33 @@
+// Copyright 2019, 2021 The Alpaca Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build aix dragonfly freebsd linux netbsd openbsd solaris
+
+package main
+
+import (
+	"os/exec"
+	"strings"
+)
+
+func findPACURL() (string, error) {
+	// Hopefully Linux, FreeBSD, Solaris, etc. will have GNOME 3 installed...
+	// TODO: Figure out how to do this for KDE.
+	cmd := exec.Command("gsettings", "get", "org.gnome.system.proxy", "autoconfig-url")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.Trim(string(out), "'\n"), nil
+}

--- a/pacfinder_unix_test.go
+++ b/pacfinder_unix_test.go
@@ -1,0 +1,56 @@
+// Copyright 2019, 2021 The Alpaca Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build aix dragonfly freebsd linux netbsd openbsd solaris
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+
+func TestFindPACURL(t *testing.T) {
+	dir, err := ioutil.TempDir("", "alpaca")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+	oldpath := os.Getenv("PATH")
+	defer require.NoError(t, os.Setenv("PATH", oldpath))
+
+	require.NoError(t, os.Setenv("PATH", dir))
+	tmpfn := filepath.Join(dir, "gsettings")
+	mockcmd := "#!/bin/sh\necho \\'http://internal.anz.com/proxy.pac\\'\n"
+	require.NoError(t, ioutil.WriteFile(tmpfn, []byte(mockcmd), 0700))
+
+	pacURL, err := findPACURL()
+	require.NoError(t, err)
+	assert.Equal(t, "http://internal.anz.com/proxy.pac", pacURL)
+}
+
+func TestFindPACURLWhenGsettingsIsntAvailable(t *testing.T) {
+	dir, err := ioutil.TempDir("", "alpaca")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+	oldpath := os.Getenv("PATH")
+	defer require.NoError(t, os.Setenv("PATH", oldpath))
+	require.NoError(t, os.Setenv("PATH", dir))
+	_, err = findPACURL()
+	require.NotNil(t, err)
+}

--- a/pacfinder_windows.go
+++ b/pacfinder_windows.go
@@ -1,0 +1,20 @@
+// Copyright 2019, 2021 The Alpaca Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+func findPACURL() (string, error) {
+	// TODO: Implement this.
+	return "", nil
+}


### PR DESCRIPTION
I'm not sure why we didn't have it set up to run Windows builds and tests on Windows itself, but this was hiding a number of bugs on Windows.