### PR TITLE
windows binaries .exe extension to build refinements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
 
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
+
     steps:
       - uses: actions/create-release@v1
         env:
@@ -27,6 +30,9 @@ jobs:
         with:
           name: upload_url
           path: upload_url.txt
+
+      - id: get_version
+        run: echo ::set-output name=version::${GITHUB_REF/refs\/tags\//}
 
   build:
     strategy:
@@ -68,7 +74,7 @@ jobs:
         run: |
           echo SDKROOT=$(xcrun --sdk macosx --show-sdk-path) >> $GITHUB_ENV
 
-      - run: go build -v -o ${{ matrix.target.goos }}-${{ matrix.target.goarch }}${{ matrix.target.ext }} .
+      - run: go build -v -o ${{ matrix.target.goos }}-${{ matrix.target.goarch }} .
         env:
           GOOS: ${{ matrix.target.goos }}
           GOARCH: ${{ matrix.target.goarch }}
@@ -90,6 +96,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.get_release_info.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: ./${{ matrix.target.goos }}-${{ matrix.target.goarch }}${{ matrix.target.ext }}
-          asset_name: ${{ matrix.target.goos }}-${{ matrix.target.goarch }}${{ matrix.target.ext }}
+          asset_path: ./${{ matrix.target.goos }}-${{ matrix.target.goarch }}
+          asset_name: alpaca_${{ needs.release.outputs.version }}_${{ matrix.target.goos }}-${{ matrix.target.goarch }}${{ matrix.target.ext }}
           asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
           - os: 'windows-latest'
             goos: 'windows'
             goarch: 'amd64'
+            ext: '.exe'
         go: [ '1.16' ]
 
     runs-on: ${{ matrix.target.os }}
@@ -67,7 +68,7 @@ jobs:
         run: |
           echo SDKROOT=$(xcrun --sdk macosx --show-sdk-path) >> $GITHUB_ENV
 
-      - run: go build -v -o ${{ matrix.target.goos }}-${{ matrix.target.goarch }} .
+      - run: go build -v -o ${{ matrix.target.goos }}-${{ matrix.target.goarch }}${{ matrix.target.ext }} .
         env:
           GOOS: ${{ matrix.target.goos }}
           GOARCH: ${{ matrix.target.goarch }}
@@ -89,6 +90,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.get_release_info.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: ./${{ matrix.target.goos }}-${{ matrix.target.goarch }}
-          asset_name: ${{ matrix.target.goos }}-${{ matrix.target.goarch }}
+          asset_path: ./${{ matrix.target.goos }}-${{ matrix.target.goarch }}${{ matrix.target.ext }}
+          asset_name: ${{ matrix.target.goos }}-${{ matrix.target.goarch }}${{ matrix.target.ext }}
           asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
 
     outputs:
       version: ${{ steps.get_version.outputs.version }}
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
 
     steps:
       - uses: actions/create-release@v1
@@ -23,13 +24,6 @@ jobs:
           draft: false
           prerelease: false
         id: create_release
-
-      - run: echo "${{ steps.create_release.outputs.upload_url }}" > upload_url.txt
-
-      - uses: actions/upload-artifact@v1
-        with:
-          name: upload_url
-          path: upload_url.txt
 
       - id: get_version
         run: echo ::set-output name=version::${GITHUB_REF/refs\/tags\//}
@@ -80,22 +74,11 @@ jobs:
           GOARCH: ${{ matrix.target.goarch }}
           CGO_ENABLED: 1
 
-      - uses: actions/download-artifact@v1
-        with:
-          name: upload_url
-
-      - id: get_release_info
-        run: |
-          echo "##[set-output name=upload_url;]$(cat upload_url/upload_url.txt)"
-        env:
-          TAG_REF_NAME: ${{ github.ref }}
-          REPOSITORY_NAME: ${{ github.repository }}
-
       - uses: actions/upload-release-asset@v1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.get_release_info.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          upload_url: ${{ needs.release.outputs.upload_url}} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
           asset_path: ./${{ matrix.target.goos }}-${{ matrix.target.goarch }}
           asset_name: alpaca_${{ needs.release.outputs.version }}_${{ matrix.target.goos }}-${{ matrix.target.goarch }}${{ matrix.target.ext }}
           asset_content_type: application/zip


### PR DESCRIPTION
EDIT: I've added two more commits.

Commits: 

1. bugfix: windows binary to include .exe extension that would otherwise make it difficult for users to execute.
2. refactor: release asset naming convention to "alpaca_[version]_[platform]?[.extentsion]"
3. refactor: the build release asset job to use the previous job outputs consistently. 


<img width="1304" alt="Screen Shot 2021-05-24 at 8 03 12 pm" src="https://user-images.githubusercontent.com/96487/119332264-b1110e00-bccb-11eb-88b7-0452af932240.png">
