### PR TITLE
Pass complete URLs to PAC script, assuming https if scheme is empty

### DIFF
--- a/pacrunner.go
+++ b/pacrunner.go
@@ -73,9 +73,14 @@ func (pr *PACRunner) Update(pacjs []byte) error {
 	return nil
 }
 
-func (pr *PACRunner) FindProxyForURL(u *url.URL) (string, error) {
+func (pr *PACRunner) FindProxyForURL(u url.URL) (string, error) {
 	pr.Lock()
 	defer pr.Unlock()
+	if u.Scheme == "" {
+		// When a net/http Server parses a CONNECT request, the URL will
+		// have no Scheme. In that case, assume the scheme is "https".
+		u.Scheme = "https"
+	}
 	if u.Scheme == "https" || u.Scheme == "wss" {
 		// Strip the path and query components of https:// URLs.
 		// https://developer.mozilla.org/en-US/docs/Web/HTTP/Proxy_servers_and_tunneling/Proxy_Auto-Configuration_(PAC)_file#Parameters

--- a/pacrunner_test.go
+++ b/pacrunner_test.go
@@ -30,19 +30,19 @@ func TestDirect(t *testing.T) {
 	var pr PACRunner
 	pacjs := []byte(`function FindProxyForURL(url, host) { return "DIRECT" }`)
 	require.NoError(t, pr.Update(pacjs))
-	proxy, err := pr.FindProxyForURL(&url.URL{Scheme: "https", Host: "anz.com"})
+	proxy, err := pr.FindProxyForURL(url.URL{Scheme: "https", Host: "anz.com"})
 	require.NoError(t, err)
 	assert.Equal(t, "DIRECT", proxy)
 }
 
-func TestPathAndQueryStripping(t *testing.T) {
+func TestFindProxyForURL(t *testing.T) {
 	tests := []struct {
 		name, input, expected string
 	}{
-		{"http", "http://anz.com/path?secret=abc123", "http://anz.com/path?secret=abc123"},
-		{"https with path and query", "https://anz.com/path?secret=123", "https://anz.com"},
-		{"wss with path", "wss://anz.com/websocket", "wss://anz.com"},
-		{"https with fragment", "https://anz.com/#fragment", "https://anz.com"},
+		{"NoScheme", "//alpaca.test", "https://alpaca.test"},
+		{"HTTP", "http://alpaca.test/a?b=c#d", "http://alpaca.test/a?b=c#d"},
+		{"HTTPS", "https://alpaca.test/a?b=c#d", "https://alpaca.test"},
+		{"WSS", "wss://alpaca.test/a?b=c#d", "wss://alpaca.test"},
 	}
 	for _, test := range tests {
 		var pr PACRunner
@@ -51,7 +51,7 @@ func TestPathAndQueryStripping(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			u, err := url.Parse(test.input)
 			require.NoError(t, err)
-			proxy, err := pr.FindProxyForURL(u)
+			proxy, err := pr.FindProxyForURL(*u)
 			require.NoError(t, err)
 			assert.Equal(t, test.expected, proxy)
 		})

--- a/proxyfinder.go
+++ b/proxyfinder.go
@@ -86,7 +86,7 @@ func (pf *ProxyFinder) findProxyForRequest(req *http.Request) (*url.URL, error) 
 		log.Printf(`[%d] %s %s via "DIRECT" (not connected)`, id, req.Method, req.URL)
 		return nil, nil
 	}
-	str, err := pf.runner.FindProxyForURL(req.URL)
+	str, err := pf.runner.FindProxyForURL(*req.URL)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Also change FindProxyForURL() to pass by value rather than by reference. This
function modifies the URL, so make sure to do that on a copy rather than on the
original.

Fixes #58