### PR TITLE
Try to determine PAC URL before downloading, rather than on startup

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,20 +35,11 @@ func whoAmI() string {
 func main() {
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 	port := flag.Int("p", 3128, "port number to listen on")
-	pacURLFromFlag := flag.String("C", "", "url of proxy auto-config (pac) file")
+	pacurl := flag.String("C", "", "url of proxy auto-config (pac) file")
 	domain := flag.String("d", "", "domain of the proxy account (for NTLM auth)")
 	username := flag.String("u", whoAmI(), "username of the proxy account (for NTLM auth)")
 	printHash := flag.Bool("H", false, "print hashed NTLM credentials for non-interactive use")
 	flag.Parse()
-
-	pacURL := *pacURLFromFlag
-	if len(pacURL) == 0 {
-		var err error
-		pacURL, err = findPACURL()
-		if err != nil {
-			log.Fatalf("Error while trying to detect PAC URL: %v", err)
-		}
-	}
 
 	var src credentialSource
 	if *domain != "" {
@@ -78,7 +69,7 @@ func main() {
 	}
 
 	pacWrapper := NewPACWrapper(PACData{Port: *port})
-	proxyFinder := NewProxyFinder(pacURL, pacWrapper)
+	proxyFinder := NewProxyFinder(*pacurl, pacWrapper)
 	proxyHandler := NewProxyHandler(a, getProxyFromContext, proxyFinder.blockProxy)
 	mux := http.NewServeMux()
 	pacWrapper.SetupHandlers(mux)


### PR DESCRIPTION
This allows Alpaca to detect changes in the system's PAC URL. Some VPN
clients change the PAC URL to a locally-hosted file upon connection, so
this needs to be checked whenever a network change is detected.