### PR TITLE
NEW: Build script with commit version

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/bash
+# local build
+version=$(git describe --tags | head -1) 
+go build -v -ldflags="-X 'main.BuildVersion=${version}'" .


### PR DESCRIPTION
@samuong indicated he would like a version number that included the current commit so he can tell what version a person is testing with. This build script provides this by passing it to the go build command using ldflags. 