### PR TITLE
Log 407 responses from proxy

### DIFF
--- a/authenticator.go
+++ b/authenticator.go
@@ -50,6 +50,7 @@ func (a authenticator) do(req *http.Request, rt http.RoundTripper) (*http.Respon
 		log.Printf("Expected response with status 407, got %s", resp.Status)
 		return resp, nil
 	}
+	log.Printf("2. got %q", resp.Status)
 	challenge, err := base64.StdEncoding.DecodeString(
 		strings.TrimPrefix(resp.Header.Get("Proxy-Authenticate"), "NTLM "))
 	if err != nil {

--- a/authenticator.go
+++ b/authenticator.go
@@ -50,7 +50,6 @@ func (a authenticator) do(req *http.Request, rt http.RoundTripper) (*http.Respon
 		log.Printf("Expected response with status 407, got %s", resp.Status)
 		return resp, nil
 	}
-	log.Printf("2. got %q", resp.Status)
 	challenge, err := base64.StdEncoding.DecodeString(
 		strings.TrimPrefix(resp.Header.Get("Proxy-Authenticate"), "NTLM "))
 	if err != nil {

--- a/proxy.go
+++ b/proxy.go
@@ -143,6 +143,7 @@ func connectViaProxy(req *http.Request, proxy string, auth *authenticator) (net.
 		log.Printf("[%d] Error reading CONNECT response: %v", id, err)
 		return nil, err
 	} else if resp.StatusCode == http.StatusProxyAuthRequired && auth != nil {
+		log.Printf("[%d] 0. got %q", id, resp.Status)
 		resp.Body.Close()
 		if err := tr.dial("tcp", proxy); err != nil {
 			log.Printf("[%d] Error re-dialling %s: %v", id, proxy, err)
@@ -153,6 +154,7 @@ func connectViaProxy(req *http.Request, proxy string, auth *authenticator) (net.
 			return nil, err
 		}
 	}
+	log.Printf("[%d] 1. got %q", id, resp.Status)
 	resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("[%d] Unexpected response status: %s", id, resp.Status)
@@ -186,6 +188,7 @@ func (ph ProxyHandler) proxyRequest(w http.ResponseWriter, req *http.Request, au
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusProxyAuthRequired && auth != nil {
+		log.Printf("[%d] 1. got %q", id, resp.Status)
 		_, err = rd.Seek(0, io.SeekStart)
 		if err != nil {
 			log.Printf("[%d] Error while seeking to start of request body: %v", id, err)
@@ -197,6 +200,7 @@ func (ph ProxyHandler) proxyRequest(w http.ResponseWriter, req *http.Request, au
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}
+			log.Printf("[%d] 3. got %q", id, resp.Status)
 			defer resp.Body.Close()
 		}
 	}

--- a/proxy.go
+++ b/proxy.go
@@ -143,7 +143,7 @@ func connectViaProxy(req *http.Request, proxy string, auth *authenticator) (net.
 		log.Printf("[%d] Error reading CONNECT response: %v", id, err)
 		return nil, err
 	} else if resp.StatusCode == http.StatusProxyAuthRequired && auth != nil {
-		log.Printf("[%d] 0. got %q", id, resp.Status)
+		log.Printf("[%d] Got %q response, retrying with auth", id, resp.Status)
 		resp.Body.Close()
 		if err := tr.dial("tcp", proxy); err != nil {
 			log.Printf("[%d] Error re-dialling %s: %v", id, proxy, err)
@@ -154,7 +154,6 @@ func connectViaProxy(req *http.Request, proxy string, auth *authenticator) (net.
 			return nil, err
 		}
 	}
-	log.Printf("[%d] 1. got %q", id, resp.Status)
 	resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("[%d] Unexpected response status: %s", id, resp.Status)
@@ -188,7 +187,7 @@ func (ph ProxyHandler) proxyRequest(w http.ResponseWriter, req *http.Request, au
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusProxyAuthRequired && auth != nil {
-		log.Printf("[%d] 1. got %q", id, resp.Status)
+		log.Printf("[%d] Got %q response, retrying with auth", id, resp.Status)
 		_, err = rd.Seek(0, io.SeekStart)
 		if err != nil {
 			log.Printf("[%d] Error while seeking to start of request body: %v", id, err)
@@ -200,7 +199,6 @@ func (ph ProxyHandler) proxyRequest(w http.ResponseWriter, req *http.Request, au
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}
-			log.Printf("[%d] 3. got %q", id, resp.Status)
 			defer resp.Body.Close()
 		}
 	}


### PR DESCRIPTION
When a proxy server responses with 407 Proxy Authentication Required, Alpaca silently retries the request with authentication. This PR adds logging so that we know when Alpaca has gone down the code path to authenticate to the proxy. This makes it easier to see what's going on in cases such as issue #44.