### PR TITLE
Try to determine PAC URL before downloading, rather than on startup

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ func whoAmI() string {
 func main() {
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 	port := flag.Int("p", 3128, "port number to listen on")
-	pacURLFromFlag := flag.String("C", "", "url of proxy auto-config (pac) file")
+	pacurl := flag.String("C", "", "url of proxy auto-config (pac) file")
 	domain := flag.String("d", "", "domain of the proxy account (for NTLM auth)")
 	username := flag.String("u", whoAmI(), "username of the proxy account (for NTLM auth)")
 	printHash := flag.Bool("H", false, "print hashed NTLM credentials for non-interactive use")
@@ -47,15 +47,6 @@ func main() {
 	if *version {
 		fmt.Println("Alpaca", BuildVersion)
 		os.Exit(0)
-	}
-
-	pacURL := *pacURLFromFlag
-	if len(pacURL) == 0 {
-		var err error
-		pacURL, err = findPACURL()
-		if err != nil {
-			log.Fatalf("Error while trying to detect PAC URL: %v", err)
-		}
 	}
 
 	var src credentialSource
@@ -86,7 +77,7 @@ func main() {
 	}
 
 	pacWrapper := NewPACWrapper(PACData{Port: *port})
-	proxyFinder := NewProxyFinder(pacURL, pacWrapper)
+	proxyFinder := NewProxyFinder(*pacurl, pacWrapper)
 	proxyHandler := NewProxyHandler(a, getProxyFromContext, proxyFinder.blockProxy)
 	mux := http.NewServeMux()
 	pacWrapper.SetupHandlers(mux)

--- a/pacfetcher.go
+++ b/pacfetcher.go
@@ -94,6 +94,9 @@ func (pf *pacFetcher) download() []byte {
 		if err != nil {
 			log.Printf("Error while trying to detect PAC URL: %v", err)
 			return nil
+		} else if pacurl == "" {
+			log.Println("No PAC URL specified or detected; all requests will be made directly")
+			return nil
 		}
 	}
 	log.Printf("Attempting to download PAC from %s", pacurl)


### PR DESCRIPTION
This pull request re-lands #76, which was accidentally merged into the wrong branch (use-operror-proxyconnect instead of master).

It also removes some additional checks which assumed that the PAC URL would be available at startup.

This PR is currently compared against reland-pr-75, but should be rebased and merged into master once reland-pr-75 lands.