### PR TITLE
Add flag to optionally listen on all interfaces

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,6 +2,7 @@ Cam Hutchison <camh@xdna.net>
 Dave Goddard <dave.goddard@anz.com>
 James Moriarty <jamespaulmoriarty@gmail.com>
 Julia Ogris <julia.ogris@gmail.com>
+Keilin Olsen <keilin.olsen@anz.com>
 Keith Ferguson <keith.ferguson@anz.com>
 Sam Uong <samuong@gmail.com>
 Seng Ern Gan <sengern.gan@anz.com>


### PR DESCRIPTION
Server currently listens on `localhost:${port}` which is fine for most scenarios
This adds the ability to optionally listen on `:${port}` instead (all local IPs)
It's unknown whether this has far reaching implications - very much included just as a jump off point for samuong/alpaca#95 if desired

Potentially addresses samuong/alpaca#95

**NB: previous commits removed since it was a tiny change and clashed with recent merges**