### PR TITLE
Add a test for HTTP/2

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -190,7 +190,7 @@ func TestWithSquid(t *testing.T) {
 	// Run (most of) Alpaca in a goroutine.
 	port, err := strconv.Atoi(findAvailablePort(t))
 	require.NoError(t, err)
-	alpaca := createServer(port, pacServer.URL, nil)
+	alpaca := createServer("localhost", port, pacServer.URL, nil)
 	go alpaca.ListenAndServe()
 	defer alpaca.Close()
 	waitForServer(alpaca.Addr)


### PR DESCRIPTION
Alpaca doesn't support HTTP/2, but clients and servers that support it can
still communicate using HTTP/2, over a CONNECT tunnel established over HTTP/1.

Fixes #6