### PR TITLE
Handle empty URLs in output from networksetup

### DIFF
--- a/pacfinder_darwin.go
+++ b/pacfinder_darwin.go
@@ -51,7 +51,7 @@ func findPACURL() (string, error) {
 		if err != nil {
 			log.Printf("Error getting auto proxy URL for %v: %v", networkService, err)
 			continue
-		} else if url == "(null)" {
+		} else if url == "(null)" || url == "" {
 			continue
 		}
 		return url, nil

--- a/pacfinder_darwin_test.go
+++ b/pacfinder_darwin_test.go
@@ -51,6 +51,12 @@ getautoproxyurl() {
 URL: http://internal.anz.com/proxy.pac
 Enabled: No
 EOF
+	elif [ "$1" = 'iPhone USB 2' ]
+	then
+		cat <<EOF
+URL: 
+Enabled: No
+EOF
 	else
 		cat <<EOF
 URL: (null)


### PR DESCRIPTION
On some machines, for some network services, networksetup returns a blank URL instead of `(null)`. This needs to be ignored by Alpaca, otherwise we'll fail to detect PAC URLs that are set in other network services.