### PR TITLE
Always check for new PAC files on darwin.

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ func whoAmI() string {
 }
 
 func main() {
-	log.SetFlags(log.LstdFlags | log.Lshortfile)
+	log.SetFlags(log.LstdFlags | log.Lshortfile | log.Lmicroseconds)
 	host := flag.String("l", "localhost", "address to listen on")
 	port := flag.Int("p", 3128, "port number to listen on")
 	pacurl := flag.String("C", "", "url of proxy auto-config (pac) file")

--- a/pacfetcher_test.go
+++ b/pacfetcher_test.go
@@ -104,7 +104,7 @@ func TestDownloadWithNetworkChanges(t *testing.T) {
 	s2 := httptest.NewServer(http.HandlerFunc(pacjsHandler("test script 2")))
 	defer s2.Close()
 	nm.changed = true
-	pf.pacurl = s2.URL
+	pf.pacFinder = newPacFinder(s2.URL)
 	assert.Equal(t, []byte("test script 2"), pf.download())
 	assert.True(t, pf.isConnected())
 }

--- a/pacfinder_darwin.go
+++ b/pacfinder_darwin.go
@@ -32,8 +32,6 @@ const CFStringRef_Const kProxiesProxyAutoConfigEnable = CFSTR("ProxyAutoConfigEn
 */
 import "C"
 import (
-	"log"
-	"time"
 	"unsafe"
 )
 
@@ -55,11 +53,11 @@ func (finder *pacFinder) findPACURL() (string, error) {
 		return finder.pacUrl, nil
 	}
 
-	start := time.Now()
+	//start := time.Now()
 	url := finder.getPACUrl()
 
-	elapsed := time.Since(start)
-	log.Printf("PacUrl found in %v", elapsed)
+	//elapsed := time.Since(start)
+	//log.Printf("PacUrl found in %v", elapsed)
 
 	return url, nil
 }

--- a/pacfinder_unix_test.go
+++ b/pacfinder_unix_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build aix || dragonfly || freebsd || linux || netbsd || openbsd || solaris
 // +build aix dragonfly freebsd linux netbsd openbsd solaris
 
 package main
@@ -24,7 +25,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
 
 func TestFindPACURL(t *testing.T) {
 	dir, err := os.MkdirTemp("", "alpaca")

--- a/pacfinder_windows.go
+++ b/pacfinder_windows.go
@@ -14,7 +14,17 @@
 
 package main
 
-func findPACURL() (string, error) {
+type pacFinder struct{}
+
+func newPacFinder() *pacFinder {
+	return &pacFinder{}
+}
+
+func (finder *pacFinder) findPACURL() (string, error) {
+	if finder.pacUrl != "" {
+		return finder.pacUrl, nil
+	}
+
 	// TODO: Implement this.
 	return "", nil
 }

--- a/proxyfinder_test.go
+++ b/proxyfinder_test.go
@@ -80,15 +80,7 @@ func TestFallbackToDirectWhenNotConnected(t *testing.T) {
 	assert.Nil(t, proxy)
 }
 
-func TestFallbackToDirectWhenNoPACURL(t *testing.T) {
-	url := ""
-	pw := NewPACWrapper(PACData{Port: 1})
-	pf := NewProxyFinder(url, pw)
-	req := httptest.NewRequest(http.MethodGet, "http://www.test", nil)
-	proxy, err := pf.findProxyForRequest(req)
-	require.NoError(t, err)
-	assert.Nil(t, proxy)
-}
+// Removed TestFallbackToDirectWhenNoPACURL - behaviour is fallback to system default when no PACURL, test case TestFallbackToDefaultWhenNoPACUrl
 
 func TestSkipBadProxies(t *testing.T) {
 	js := `function FindProxyForURL(url, host) { return "PROXY primary:80; PROXY backup:80" }`


### PR DESCRIPTION
This PR suggests a way of using cgo to performantly (< 100uS) pull the auto proxy configuration from the darwin system to ensure always having the current setting.