### PR TITLE
Add distribution packages information

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ $ go get -v -u github.com/samuong/alpaca
 
 Alpaca can be downloaded from the [GitHub releases page][1].
 
+## Install from distribution packages
+
+[![Packaging status](https://repology.org/badge/vertical-allrepos/alpaca-proxy.svg)](https://repology.org/project/alpaca-proxy/versions)
+
 ## Usage
 
 Start Alpaca by running the `alpaca` binary.


### PR DESCRIPTION
Hello,

I took the liberty of packaging alpaca for ArchLinux (in [AUR](https://aur.archlinux.org/packages/alpaca-proxy)) today.
Having a reference to packaged versions in the upstream project seems like a good idea.

This pull request includes a repology badge, which will automatically include other distribution packages if they appear.
As the name 'alpaca' is claimed by multiple projects, I went with 'alpaca-proxy'.