### PR TITLE
Remove dodgy connection check

### DIFF
--- a/pacfetcher_test.go
+++ b/pacfetcher_test.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -125,14 +124,8 @@ func TestPacFromFilesystem(t *testing.T) {
 	pacPath := path.Join(tempdir, "test.pac")
 	require.NoError(t, os.WriteFile(pacPath, content, 0644))
 	pacURL := &url.URL{Scheme: "file", Path: filepath.ToSlash(pacPath)}
-
 	pf := newPACFetcher(pacURL.String())
-	pf.monitor = &netMonitorImpl{
-		getAddrs: func() ([]net.Addr, error) {
-			return []net.Addr{&net.IPAddr{IP: net.ParseIP("127.0.0.1")}}, nil
-		},
-	}
-
+	pf.monitor = newNetMonitor()
 	assert.Equal(t, content, pf.download())
 	assert.True(t, pf.isConnected())
 }

--- a/pacfetcher_test.go
+++ b/pacfetcher_test.go
@@ -15,8 +15,6 @@
 package main
 
 import (
-	"context"
-	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -118,27 +116,6 @@ func TestResponseLimit(t *testing.T) {
 	assert.False(t, pf.isConnected())
 }
 
-type testNetwork struct {
-	connected bool
-}
-
-func (tn testNetwork) InterfaceAddrs() ([]net.Addr, error) {
-	addr := func(s string) *net.IPAddr { return &net.IPAddr{IP: net.ParseIP(s)} }
-	if tn.connected {
-		return []net.Addr{addr("127.0.0.1"), addr("192.0.2.1")}, nil
-	} else {
-		return []net.Addr{addr("127.0.0.1"), addr("198.51.100.1")}, nil
-	}
-}
-
-func (tn testNetwork) LookupAddr(ctx context.Context, addr string) ([]string, error) {
-	if tn.connected {
-		return []string{}, fmt.Errorf("lookup %s: Name or service not known", addr)
-	} else {
-		return []string{"dns.google."}, nil
-	}
-}
-
 func TestPacFromFilesystem(t *testing.T) {
 	// Set up a test PAC file
 	content := []byte(`function FindProxyForURL(url, host) { return "DIRECT" }`)
@@ -149,18 +126,13 @@ func TestPacFromFilesystem(t *testing.T) {
 	require.NoError(t, os.WriteFile(pacPath, content, 0644))
 	pacURL := &url.URL{Scheme: "file", Path: filepath.ToSlash(pacPath)}
 
-	tn := testNetwork{false}
 	pf := newPACFetcher(pacURL.String())
 	pf.monitor = &netMonitorImpl{
-		getAddrs: func() ([]net.Addr, error) { return tn.InterfaceAddrs() },
-	}
-	pf.lookupAddr = func(ctx context.Context, addr string) ([]string, error) {
-		return tn.LookupAddr(ctx, addr)
+		getAddrs: func() ([]net.Addr, error) {
+			return []net.Addr{&net.IPAddr{IP: net.ParseIP("127.0.0.1")}}, nil
+		},
 	}
 
-	assert.Equal(t, content, pf.download())
-	assert.False(t, pf.isConnected())
-	tn.connected = true
 	assert.Equal(t, content, pf.download())
 	assert.True(t, pf.isConnected())
 }


### PR DESCRIPTION
This behaviour worked well on some corporate networks, but breaks on others. From now on, users who use a custom PAC file with a file:// URL will need to do this check themselves, before returning a PROXY directive.

Fixes #106 