### PR TITLE
Write CONNECT response in a single call to Conn.Write()

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -117,13 +117,13 @@ func (ph ProxyHandler) handleConnect(w http.ResponseWriter, req *http.Request) {
 	// Write the response directly to the client connection. If we use Go's ResponseWriter, it
 	// will automatically insert a Content-Length header, which is not allowed in a 2xx CONNECT
 	// response (see https://tools.ietf.org/html/rfc7231#section-4.3.6).
-	resp := &http.Response{
-		StatusCode:    http.StatusOK,
-		ProtoMajor:    req.ProtoMajor,
-		ProtoMinor:    req.ProtoMinor,
-		ContentLength: -1,
+	var resp []byte
+	if req.ProtoAtLeast(1, 1) {
+		resp = []byte("HTTP/1.1 200 Connection Established\r\n\r\n")
+	} else {
+		resp = []byte("HTTP/1.0 200 Connection Established\r\n\r\n")
 	}
-	if err := resp.Write(client); err != nil {
+	if _, err := client.Write(resp); err != nil {
 		log.Printf("[%d] Error writing response: %v", id, err)
 		return
 	}


### PR DESCRIPTION
This introduces a few changes from the previous version:

1. If we build an http.Response and call its Write() function, it will
   write the response line-by-line. This seems to be the cause of some
   flakiness with clients that start tunnel mode after the status line,
   rather than after the response header, as per RFC9110 9.3.6.

2. We only support HTTP 1.0 and 1.1. We no longer just blindly copy over
   the HTTP version from the client request.

3. The status code is still 200 but the status message has changed from
   "OK" to "Connection Established", in line with what other proxies are
   doing (I tested Squid, Martian and Zscaler). Clients ignore this
   anyway, going with the status code, so this shouldn't matter.

4. We no longer send a 'Connection: close' header with the response.
   This is redundant in a CONNECT request, and follows what other
   proxies (Squid, Martian and Zscaler) do.