### PR TITLE
Fix: dual stack network not working

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,3 +9,4 @@ Kyle Cronin <cronik@users.noreply.github.com>
 Marcelo Cantos <marcelo.cantos@gmail.com>
 Sam Uong <samuong@gmail.com>
 Seng Ern Gan <sengern.gan@anz.com>
+Lucas Santiago <lu.santi.oli@gmail.com>

--- a/main.go
+++ b/main.go
@@ -38,8 +38,6 @@ func whoAmI() string {
 
 type stringArrayFlag []string
 
-var hosts stringArrayFlag
-
 func (s *stringArrayFlag) String() string {
 	return fmt.Sprintf("%v", *s)
 }
@@ -54,6 +52,8 @@ func (s *stringArrayFlag) Set(value string) error {
 
 func main() {
 	log.SetFlags(log.LstdFlags | log.Lshortfile | log.Lmicroseconds)
+
+	var hosts stringArrayFlag
 	flag.Var(&hosts, "l", "address to listen on")
 	port := flag.Int("p", 3128, "port number to listen on")
 	pacurl := flag.String("C", "", "url of proxy auto-config (pac) file")


### PR DESCRIPTION
Why not set dual stack IPv4 and IPv6 by default? 
In that cause both protocols can coexist and the user can choose the one that it wants the most. The current implementation works as a tunnel as well. Example:

My Package -> Proxy: https://[::1]:3128 -> Network: some IPv4