### PR TITLE
PAC URL detection on Darwin to use SCDynamicStoreCopyProxies instead …

### DIFF
--- a/pacfinder_darwin.go
+++ b/pacfinder_darwin.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package main
 
 /*
@@ -20,46 +19,32 @@ package main
 #include <SystemConfiguration/SystemConfiguration.h>
 
 static SCDynamicStoreRef SCDynamicStoreCreate_trampoline() {
-	return SCDynamicStoreCreate(kCFAllocatorDefault, CFSTR("alpaca"), NULL, NULL);
+    return SCDynamicStoreCreate(kCFAllocatorDefault, CFSTR("alpaca"), NULL, NULL);
 }
 
 typedef const CFStringRef CFStringRef_Const;
-
-const CFStringRef_Const kProxiesSettings = CFSTR("State:/Network/Global/Proxies");
-const CFStringRef_Const kProxiesAutoConfigURLString = CFSTR("ProxyAutoConfigURLString");
-const CFStringRef_Const kProxiesProxyAutoConfigEnable = CFSTR("ProxyAutoConfigEnable");
-
 */
 import "C"
 import (
+	"log"
 	"unsafe"
 )
 
 type pacFinder struct {
 	pacUrl   string
 	storeRef C.SCDynamicStoreRef
+	auto     bool
 }
 
 func newPacFinder(pacUrl string) *pacFinder {
 	if pacUrl != "" {
-		return &pacFinder{pacUrl, 0}
+		return &pacFinder{pacUrl, 0, false}
 	}
-
-	return &pacFinder{"", C.SCDynamicStoreCreate_trampoline()}
-}
-
-func (finder *pacFinder) findPACURL() (string, error) {
-	if finder.storeRef == 0 {
-		return finder.pacUrl, nil
+	storeRef := C.SCDynamicStoreCreate_trampoline()
+	if storeRef == 0 {
+		log.Fatalf("Failed to create SCDynamicStore")
 	}
-
-	//start := time.Now()
-	url := finder.getPACUrl()
-
-	//elapsed := time.Since(start)
-	//log.Printf("PacUrl found in %v", elapsed)
-
-	return url, nil
+	return &pacFinder{"", storeRef, true}
 }
 
 func (finder *pacFinder) pacChanged() bool {
@@ -67,40 +52,61 @@ func (finder *pacFinder) pacChanged() bool {
 		finder.pacUrl = url
 		return true
 	}
-
 	return false
 }
 
-func (finder *pacFinder) getPACUrl() string {
-	dict := C.CFDictionaryRef(C.SCDynamicStoreCopyValue(finder.storeRef, C.kProxiesSettings))
-
-	if dict == 0 {
-		return ""
+func (finder *pacFinder) findPACURL() (string, error) {
+	if finder.storeRef == 0 {
+		return finder.pacUrl, nil
 	}
 
-	defer C.CFRelease(C.CFTypeRef(dict))
+	// Using SCDynamicStoreCopyProxies to get PAC URL
+	pacUrl := finder.getPACUrlFromSCDynamicStoreCopyProxies()
+	if pacUrl != "" {
+		// log.Printf("Using PAC URL from SCDynamicStoreCopyProxies method: %s", pacUrl)
+		return pacUrl, nil
+	}
 
-	pacEnabled := C.CFNumberRef(C.CFDictionaryGetValue(dict, unsafe.Pointer(C.kProxiesProxyAutoConfigEnable)))
+	// log.Printf("No PAC URL found using SCDynamicStoreCopyProxies")
+	return "", nil
+}
+
+func (finder *pacFinder) getPACUrlFromSCDynamicStoreCopyProxies() string {
+	proxySettings := C.SCDynamicStoreCopyProxies(finder.storeRef)
+	if proxySettings == 0 {
+		// log.Printf("No proxy settings found using SCDynamicStoreCopyProxies")
+		return ""
+	}
+	defer C.CFRelease(C.CFTypeRef(proxySettings))
+
+	kSCPropNetProxiesProxyAutoConfigEnable := CFStringCreateWithCString("ProxyAutoConfigEnable")
+	kSCPropNetProxiesProxyAutoConfigURLString := CFStringCreateWithCString("ProxyAutoConfigURLString")
+
+	pacEnabled := C.CFNumberRef(C.CFDictionaryGetValue(proxySettings, unsafe.Pointer(kSCPropNetProxiesProxyAutoConfigEnable)))
 	if pacEnabled == 0 {
+		// log.Printf("PAC enable flag not found in proxy settings using SCDynamicStoreCopyProxies")
 		return ""
 	}
 
 	var enabled C.int
-	C.CFNumberGetValue(pacEnabled, C.kCFNumberIntType, unsafe.Pointer(&enabled))
+	if C.CFNumberGetValue(pacEnabled, C.kCFNumberIntType, unsafe.Pointer(&enabled)) == 0 {
+		// log.Printf("Could not retrieve value of PAC enabled flag using SCDynamicStoreCopyProxies")
+		return ""
+	}
+
 	if enabled == 0 {
+		// log.Printf("PAC is not enabled using SCDynamicStoreCopyProxies")
 		return ""
 	}
 
-	url := C.CFStringRef_Const(C.CFDictionaryGetValue(dict, unsafe.Pointer(C.kProxiesAutoConfigURLString)))
-
-	if url == 0 {
+	pacURL := C.CFStringRef(C.CFDictionaryGetValue(proxySettings, unsafe.Pointer(kSCPropNetProxiesProxyAutoConfigURLString)))
+	if pacURL == 0 {
+		// log.Printf("PAC URL not found in proxy settings using SCDynamicStoreCopyProxies")
 		return ""
 	}
 
-	return CFStringToString(url)
+	return CFStringToString(pacURL)
 }
-
-// CGO Helpers below..
 
 // CFStringToString converts a CFStringRef to a string.
 func CFStringToString(s C.CFStringRef) string {
@@ -108,16 +114,27 @@ func CFStringToString(s C.CFStringRef) string {
 	if p != nil {
 		return C.GoString(p)
 	}
+
 	length := C.CFStringGetLength(s)
 	if length == 0 {
 		return ""
 	}
+
 	maxBufLen := C.CFStringGetMaximumSizeForEncoding(length, C.kCFStringEncodingUTF8)
 	if maxBufLen == 0 {
 		return ""
 	}
+
 	buf := make([]byte, maxBufLen)
 	var usedBufLen C.CFIndex
-	_ = C.CFStringGetBytes(s, C.CFRange{0, length}, C.kCFStringEncodingUTF8, C.UInt8(0), C.false, (*C.UInt8)(&buf[0]), maxBufLen, &usedBufLen)
+	_ = C.CFStringGetBytes(s, C.CFRange{0, length}, C.kCFStringEncodingUTF8, 0, C.Boolean(0), (*C.UInt8)(&buf[0]), maxBufLen, &usedBufLen)
 	return string(buf[:usedBufLen])
+}
+
+// Helper function to create a CFStringRef from a Go string
+func CFStringCreateWithCString(s string) C.CFStringRef {
+	cs := C.CString(s)
+	defer C.free(unsafe.Pointer(cs))
+
+	return C.CFStringCreateWithCString(C.kCFAllocatorDefault, cs, C.kCFStringEncodingUTF8)
 }

--- a/pacfinder_darwin.go
+++ b/pacfinder_darwin.go
@@ -61,18 +61,6 @@ func (finder *pacFinder) findPACURL() (string, error) {
 		return finder.pacUrl, nil
 	}
 
-	// Using SCDynamicStoreCopyProxies to get PAC URL
-	pacUrl := finder.getPACUrlFromSCDynamicStoreCopyProxies()
-	if pacUrl != "" {
-		// log.Printf("Using PAC URL from SCDynamicStoreCopyProxies method: %s", pacUrl)
-		return pacUrl, nil
-	}
-
-	// log.Printf("No PAC URL found using SCDynamicStoreCopyProxies")
-	return "", nil
-}
-
-func (finder *pacFinder) getPACUrlFromSCDynamicStoreCopyProxies() string {
 	proxySettings := C.SCDynamicStoreCopyProxies(finder.storeRef)
 	if proxySettings == 0 {
 		// log.Printf("No proxy settings found using SCDynamicStoreCopyProxies")

--- a/pacfinder_darwin.go
+++ b/pacfinder_darwin.go
@@ -42,7 +42,8 @@ func newPacFinder(pacUrl string) *pacFinder {
 	}
 	storeRef := C.SCDynamicStoreCreate_trampoline()
 	if storeRef == 0 {
-		log.Fatalf("Failed to create SCDynamicStore")
+		log.Print("Unable to access system network information")
+		return &pacFinder{"", 0}
 	}
 	return &pacFinder{"", storeRef, true}
 }

--- a/pacfinder_darwin_test.go
+++ b/pacfinder_darwin_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestFindPACURLStatic(t *testing.T) {
-	pac := "http://internal.anz.com/proxy.pac"
+	pac := "http://internal.example.com/proxy.pac"
 	finder := newPacFinder(pac)
 
 	foundPac, _ := finder.findPACURL()

--- a/pacfinder_unix_test.go
+++ b/pacfinder_unix_test.go
@@ -35,13 +35,13 @@ func TestFindPACURL(t *testing.T) {
 
 	require.NoError(t, os.Setenv("PATH", dir))
 	tmpfn := filepath.Join(dir, "gsettings")
-	mockcmd := "#!/bin/sh\necho \\'http://internal.anz.com/proxy.pac\\'\n"
+	mockcmd := "#!/bin/sh\necho \\'http://internal.example.com/proxy.pac\\'\n"
 	require.NoError(t, os.WriteFile(tmpfn, []byte(mockcmd), 0700))
 
 	pf := newPacFinder("")
 	pacURL, err := pf.findPACURL()
 	require.NoError(t, err)
-	assert.Equal(t, "http://internal.anz.com/proxy.pac", pacURL)
+	assert.Equal(t, "http://internal.example.com/proxy.pac", pacURL)
 }
 
 func TestFindPACURLWhenGsettingsIsntAvailable(t *testing.T) {


### PR DESCRIPTION
PAC URL detection on Darwin to use SCDynamicStoreCopyProxies instead of SCDynamicStoreCopyValue
<img width="1087" height="416" alt="image" src="https://github.com/user-attachments/assets/b31549b7-1aaa-40b6-9959-662edb8879ec" />

Continuation of https://github.com/samuong/alpaca/pull/147 [CLOSED]