### PR TITLE
Feat: Add support for data URL encoded PACs

### DIFF
--- a/pacfetcher.go
+++ b/pacfetcher.go
@@ -30,6 +30,11 @@ import (
 // The maximum size (in bytes) allowed for a PAC script. At 1 MB, this matches the limit in Chrome.
 const maxResponseBytes = 1 * 1024 * 1024
 
+// The maximum size (in bytes) allowed for a data URL.
+// Chromium and Firefox limit data URLs to 512MB.
+// See https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Schemes/data#length_limitations
+const maxDataURLLength = 512 * 1024 * 1024
+
 // The time to wait before retrying a failed PAC download. This is similar to Chrome's delay:
 // https://cs.chromium.org/chromium/src/net/proxy_resolution/proxy_resolution_service.cc?l=96&rcl=3db5f65968c3ecab3932c1ff7367ad28834f9502
 var delayAfterFailedDownload = 2 * time.Second
@@ -95,6 +100,11 @@ func decodeDataURL(uri string) ([]byte, error) {
 	if parsedURL.Scheme != "data" {
 		return nil, nil
 	}
+
+	if len(uri) > maxDataURLLength {
+		return nil, fmt.Errorf("Error parsing data URL: PAC JS is too big (limit is %d bytes)", maxDataURLLength)
+	}
+
 	metadata, data, ok := strings.Cut(parsedURL.Opaque, ",")
 	if !ok {
 		return nil, fmt.Errorf("Error parsing data URL: Invalid Format")
@@ -105,18 +115,12 @@ func decodeDataURL(uri string) ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("Error decoding base64 data URL: %w", err)
 		}
-		if len(bytes) > maxResponseBytes {
-			return nil, fmt.Errorf("Error parsing base64 data URL: PAC JS is too big (limit is %d bytes)", maxResponseBytes)
-		}
 		return bytes, nil
 	}
 
 	decoded, err := url.QueryUnescape(data)
 	if err != nil {
 		return nil, fmt.Errorf("Error parsing data URL: %w", err)
-	}
-	if len(decoded) > maxResponseBytes {
-		return nil, fmt.Errorf("Error parsing data URL: PAC JS is too big (limit is %d bytes)", maxResponseBytes)
 	}
 	return []byte(decoded), nil
 }

--- a/pacfetcher.go
+++ b/pacfetcher.go
@@ -40,10 +40,10 @@ const maxDataURLLength = 512 * 1024 * 1024
 var delayAfterFailedDownload = 2 * time.Second
 
 type pacFetcher struct {
-	pacFinder  *pacFinder
-	monitor    netMonitor
-	client     *http.Client
-	connected  bool
+	pacFinder *pacFinder
+	monitor   netMonitor
+	client    *http.Client
+	connected bool
 	//cache  []byte
 	//modified time.Time
 	//fetched time.Time
@@ -70,9 +70,9 @@ func newPACFetcher(pacurl string) *pacFetcher {
 		client.Transport = &http.Transport{Proxy: nil}
 	}
 	return &pacFetcher{
-		pacFinder:  newPacFinder(pacurl),
-		monitor:    newNetMonitor(),
-		client:     client,
+		pacFinder: newPacFinder(pacurl),
+		monitor:   newNetMonitor(),
+		client:    client,
 	}
 }
 
@@ -94,7 +94,7 @@ func decodeDataURL(uri string) ([]byte, error) {
 	parsedURL, err := url.Parse(uri)
 
 	if err != nil {
-		return nil, fmt.Errorf("Error parsing pac url: %w", err)
+		return nil, fmt.Errorf("error parsing pac url: %w", err)
 	}
 
 	if parsedURL.Scheme != "data" {
@@ -102,25 +102,26 @@ func decodeDataURL(uri string) ([]byte, error) {
 	}
 
 	if len(uri) > maxDataURLLength {
-		return nil, fmt.Errorf("Error parsing data URL: PAC JS is too big (limit is %d bytes)", maxDataURLLength)
+		return nil, fmt.Errorf("error parsing data URL: PAC JS is too big (limit is %d bytes)",
+			maxDataURLLength)
 	}
 
 	metadata, data, ok := strings.Cut(parsedURL.Opaque, ",")
 	if !ok {
-		return nil, fmt.Errorf("Error parsing data URL: Invalid Format")
+		return nil, fmt.Errorf("error parsing data URL: invalid format")
 	}
 
 	if strings.HasSuffix(metadata, ";base64") {
 		bytes, err := base64.StdEncoding.DecodeString(data)
 		if err != nil {
-			return nil, fmt.Errorf("Error decoding base64 data URL: %w", err)
+			return nil, fmt.Errorf("error decoding base64 data URL: %w", err)
 		}
 		return bytes, nil
 	}
 
 	decoded, err := url.PathUnescape(data)
 	if err != nil {
-		return nil, fmt.Errorf("Error parsing data URL: %w", err)
+		return nil, fmt.Errorf("error parsing data URL: %w", err)
 	}
 	return []byte(decoded), nil
 }

--- a/pacfetcher.go
+++ b/pacfetcher.go
@@ -87,16 +87,16 @@ func requireOK(resp *http.Response, err error) (*http.Response, error) {
 // It supports both base64 and URL-encoded data, and enforces the maxResponseBytes size limit.
 // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs for details.
 func decodeDataURL(uri string) ([]byte, error) {
-	parsed_url, err := url.Parse(uri)
+	parsedURL, err := url.Parse(uri)
 
 	if err != nil {
 		return nil, fmt.Errorf("Error parsing pac url: %w", err)
 	}
 
-	if parsed_url.Scheme != "data" {
+	if parsedURL.Scheme != "data" {
 		return nil, nil
 	}
-	parts := strings.SplitN(parsed_url.Opaque, ",", 2)
+	parts := strings.SplitN(parsedURL.Opaque, ",", 2)
 	if len(parts) < 2 {
 		return nil, fmt.Errorf("Error parsing data URL: Invalid Format")
 	}

--- a/pacfetcher.go
+++ b/pacfetcher.go
@@ -23,7 +23,6 @@ import (
 	"net/http"
 	"net/url"
 	"runtime"
-	"slices"
 	"strings"
 	"time"
 )
@@ -96,14 +95,13 @@ func decodeDataURL(uri string) ([]byte, error) {
 	if parsedURL.Scheme != "data" {
 		return nil, nil
 	}
-	parts := strings.SplitN(parsedURL.Opaque, ",", 2)
-	if len(parts) < 2 {
+	metadata, data, ok := strings.Cut(parsedURL.Opaque, ",")
+	if !ok {
 		return nil, fmt.Errorf("Error parsing data URL: Invalid Format")
 	}
 
-	isBase64 := slices.Contains(strings.Split(parts[0], ";"), "base64")
-	if isBase64 {
-		bytes, err := base64.StdEncoding.DecodeString(parts[1])
+	if strings.HasSuffix(metadata, ";base64") {
+		bytes, err := base64.StdEncoding.DecodeString(data)
 		if err != nil {
 			return nil, fmt.Errorf("Error parsing base64 data URL: %w", err)
 		}
@@ -113,7 +111,7 @@ func decodeDataURL(uri string) ([]byte, error) {
 		return bytes, nil
 	}
 
-	decoded, err := url.QueryUnescape(parts[1])
+	decoded, err := url.QueryUnescape(data)
 	if err != nil {
 		return nil, fmt.Errorf("Error parsing data URL: %w", err)
 	}

--- a/pacfetcher.go
+++ b/pacfetcher.go
@@ -118,7 +118,7 @@ func decodeDataURL(uri string) ([]byte, error) {
 		return bytes, nil
 	}
 
-	decoded, err := url.QueryUnescape(data)
+	decoded, err := url.PathUnescape(data)
 	if err != nil {
 		return nil, fmt.Errorf("Error parsing data URL: %w", err)
 	}

--- a/pacfetcher.go
+++ b/pacfetcher.go
@@ -16,11 +16,14 @@ package main
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"runtime"
+	"slices"
 	"strings"
 	"time"
 )
@@ -80,6 +83,46 @@ func requireOK(resp *http.Response, err error) (*http.Response, error) {
 	}
 }
 
+// decodeDataURL decodes a data URL (e.g., data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==).
+// It supports both base64 and URL-encoded data, and enforces the maxResponseBytes size limit.
+// See https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs for details.
+func decodeDataURL(uri string) ([]byte, error) {
+	parsed_url, err := url.Parse(uri)
+
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing pac url: %w", err)
+	}
+
+	if parsed_url.Scheme != "data" {
+		return nil, nil
+	}
+	parts := strings.SplitN(parsed_url.Opaque, ",", 2)
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("Error parsing data URL: Invalid Format")
+	}
+
+	isBase64 := slices.Contains(strings.Split(parts[0], ";"), "base64")
+	if isBase64 {
+		bytes, err := base64.StdEncoding.DecodeString(parts[1])
+		if err != nil {
+			return nil, fmt.Errorf("Error parsing base64 data URL: %w", err)
+		}
+		if len(bytes) > maxResponseBytes {
+			return nil, fmt.Errorf("Error parsing base64 data URL: PAC JS is too big (limit is %d bytes)", maxResponseBytes)
+		}
+		return bytes, nil
+	}
+
+	decoded, err := url.QueryUnescape(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing data URL: %w", err)
+	}
+	if len(decoded) > maxResponseBytes {
+		return nil, fmt.Errorf("Error parsing data URL: PAC JS is too big (limit is %d bytes)", maxResponseBytes)
+	}
+	return []byte(decoded), nil
+}
+
 func (pf *pacFetcher) download() []byte {
 	// TODO: Combine pacChanged() and findPACURL() as described in
 	// https://github.com/samuong/alpaca/pull/156#issuecomment-3125070335
@@ -98,6 +141,18 @@ func (pf *pacFetcher) download() []byte {
 	}
 
 	log.Printf("Attempting to download PAC from %s", pacurl)
+
+	pac, err := decodeDataURL(pacurl)
+	if err != nil {
+		log.Printf("Error downloading PAC file: %v", err)
+		return nil
+	}
+
+	if pac != nil {
+		pf.connected = true
+		return pac
+	}
+
 	resp, err := requireOK(pf.client.Get(pacurl))
 	if err != nil {
 		// Sometimes, if we try to download too soon after a network change, the PAC

--- a/pacfetcher.go
+++ b/pacfetcher.go
@@ -103,7 +103,7 @@ func decodeDataURL(uri string) ([]byte, error) {
 	if strings.HasSuffix(metadata, ";base64") {
 		bytes, err := base64.StdEncoding.DecodeString(data)
 		if err != nil {
-			return nil, fmt.Errorf("Error parsing base64 data URL: %w", err)
+			return nil, fmt.Errorf("Error decoding base64 data URL: %w", err)
 		}
 		if len(bytes) > maxResponseBytes {
 			return nil, fmt.Errorf("Error parsing base64 data URL: PAC JS is too big (limit is %d bytes)", maxResponseBytes)

--- a/pacfetcher_test.go
+++ b/pacfetcher_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019, 2021, 2022 The Alpaca Authors
+// Copyright 2019, 2021, 2022, 2025 The Alpaca Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pacfetcher_test.go
+++ b/pacfetcher_test.go
@@ -160,5 +160,5 @@ func TestDecodeDataURL_NonDataScheme(t *testing.T) {
 	uri := "http://example.com"
 	got, err := decodeDataURL(uri)
 	assert.Nil(t, got)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }

--- a/pacfetcher_test.go
+++ b/pacfetcher_test.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"bytes"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -134,37 +133,20 @@ func TestPacFromFilesystem(t *testing.T) {
 func TestDecodeDataURL_Base64(t *testing.T) {
 	uri := "data:application/x-ns-proxy-autoconfig;base64,ZnVuY3Rpb24gRmluZFByb3h5Rm9yVVJMKHVybCwgaG9zdCkgewogIHJldHVybiAiUFJPWFkgcHJveHk6ODA4MCI7Cn0K"
 	want := []byte("function FindProxyForURL(url, host) {\n  return \"PROXY proxy:8080\";\n}\n")
-	got, err := decodeDataURL(uri)
-	if err != nil {
-		t.Errorf("decodeDataURL() error = %v, wantErr %v", err, false)
-		return
-	}
-	if !bytes.Equal(got, want) {
-		t.Errorf("decodeDataURL() = %v, want %v", string(got), string(want))
-	}
+	pf := newPACFetcher(uri)
+	assert.Equal(t, want, pf.download())
 }
 
 func TestDecodeDataURL_URLEncoded(t *testing.T) {
 	uri := "data:,function%20FindProxyForURL(url%2C%20host)%20%7B%0A%20%20return%20%22PROXY%20proxy%3A8080%22%3B%0A%7D%0A"
-	want := []byte("function FindProxyForURL(url, host) {\n  return \"PROXY proxy:8080\";\n}\n")
-	got, err := decodeDataURL(uri)
-	if err != nil {
-		t.Errorf("decodeDataURL() error = %v, wantErr %v", err, false)
-		return
-	}
-	if !bytes.Equal(got, want) {
-		t.Errorf("decodeDataURL() = %v, want %v", string(got), string(want))
-	}
+	want := "function FindProxyForURL(url, host) {\n  return \"PROXY proxy:8080\";\n}\n"
+	pf := newPACFetcher(uri)
+	assert.Equal(t, want, string(pf.download()))
 }
 
 func TestDecodeDataURL_NonDataScheme(t *testing.T) {
 	uri := "http://example.com"
 	got, err := decodeDataURL(uri)
-	if err != nil {
-		t.Errorf("decodeDataURL() error = %v, wantErr %v", err, false)
-		return
-	}
-	if got != nil {
-		t.Errorf("decodeDataURL() = %v, want %v", got, nil)
-	}
+	assert.Nil(t, got)
+	assert.Nil(t, err)
 }

--- a/pacfetcher_test.go
+++ b/pacfetcher_test.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"bytes"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -128,4 +129,42 @@ func TestPacFromFilesystem(t *testing.T) {
 	pf.monitor = newNetMonitor()
 	assert.Equal(t, content, pf.download())
 	assert.True(t, pf.isConnected())
+}
+
+func TestDecodeDataURL_Base64(t *testing.T) {
+	uri := "data:application/x-ns-proxy-autoconfig;base64,ZnVuY3Rpb24gRmluZFByb3h5Rm9yVVJMKHVybCwgaG9zdCkgewogIHJldHVybiAiUFJPWFkgcHJveHk6ODA4MCI7Cn0K"
+	want := []byte("function FindProxyForURL(url, host) {\n  return \"PROXY proxy:8080\";\n}\n")
+	got, err := decodeDataURL(uri)
+	if err != nil {
+		t.Errorf("decodeDataURL() error = %v, wantErr %v", err, false)
+		return
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("decodeDataURL() = %v, want %v", string(got), string(want))
+	}
+}
+
+func TestDecodeDataURL_URLEncoded(t *testing.T) {
+	uri := "data:,function%20FindProxyForURL(url%2C%20host)%20%7B%0A%20%20return%20%22PROXY%20proxy%3A8080%22%3B%0A%7D%0A"
+	want := []byte("function FindProxyForURL(url, host) {\n  return \"PROXY proxy:8080\";\n}\n")
+	got, err := decodeDataURL(uri)
+	if err != nil {
+		t.Errorf("decodeDataURL() error = %v, wantErr %v", err, false)
+		return
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("decodeDataURL() = %v, want %v", string(got), string(want))
+	}
+}
+
+func TestDecodeDataURL_NonDataScheme(t *testing.T) {
+	uri := "http://example.com"
+	got, err := decodeDataURL(uri)
+	if err != nil {
+		t.Errorf("decodeDataURL() error = %v, wantErr %v", err, false)
+		return
+	}
+	if got != nil {
+		t.Errorf("decodeDataURL() = %v, want %v", got, nil)
+	}
 }

--- a/pacfetcher_test.go
+++ b/pacfetcher_test.go
@@ -138,12 +138,14 @@ func TestDecodeDataURL(t *testing.T) {
 	}{
 		{
 			"Base64",
-			"data:application/x-ns-proxy-autoconfig;base64,ZnVuY3Rpb24gRmluZFByb3h5Rm9yVVJMKHVybCwgaG9zdCkgewogIHJldHVybiAiUFJPWFkgcHJveHk6ODA4MCI7Cn0K",
+			"data:application/x-ns-proxy-autoconfig;base64,ZnVuY3Rpb24gRmluZFByb3h5Rm9yVVJMKHVybCwgaG" +
+				"9zdCkgewogIHJldHVybiAiUFJPWFkgcHJveHk6ODA4MCI7Cn0K",
 			"function FindProxyForURL(url, host) {\n  return \"PROXY proxy:8080\";\n}\n",
 		},
 		{
 			"URLEncoded",
-			"data:,function%20FindProxyForURL(url%2C%20host)%20%7B%0A%20%20return%20%22PROXY%20proxy%3A8080%22%3B%0A%7D%0A",
+			"data:,function%20FindProxyForURL(url%2C%20host)%20%7B%0A%20%20return%20%22PROXY%20proxy%3A" +
+				"8080%22%3B%0A%7D%0A",
 			"function FindProxyForURL(url, host) {\n  return \"PROXY proxy:8080\";\n}\n",
 		},
 		{

--- a/pacfetcher_test.go
+++ b/pacfetcher_test.go
@@ -146,6 +146,11 @@ func TestDecodeDataURL(t *testing.T) {
 			"data:,function%20FindProxyForURL(url%2C%20host)%20%7B%0A%20%20return%20%22PROXY%20proxy%3A8080%22%3B%0A%7D%0A",
 			"function FindProxyForURL(url, host) {\n  return \"PROXY proxy:8080\";\n}\n",
 		},
+		{
+			"URLEncodedWithPlus",
+			"data:,foo+bar",
+			"foo+bar",
+		},
 	}
 
 	for _, test := range tests {

--- a/pacfetcher_test.go
+++ b/pacfetcher_test.go
@@ -130,18 +130,30 @@ func TestPacFromFilesystem(t *testing.T) {
 	assert.True(t, pf.isConnected())
 }
 
-func TestDecodeDataURL_Base64(t *testing.T) {
-	uri := "data:application/x-ns-proxy-autoconfig;base64,ZnVuY3Rpb24gRmluZFByb3h5Rm9yVVJMKHVybCwgaG9zdCkgewogIHJldHVybiAiUFJPWFkgcHJveHk6ODA4MCI7Cn0K"
-	want := []byte("function FindProxyForURL(url, host) {\n  return \"PROXY proxy:8080\";\n}\n")
-	pf := newPACFetcher(uri)
-	assert.Equal(t, want, pf.download())
-}
+func TestDecodeDataURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		uri      string
+		expected string
+	}{
+		{
+			"Base64",
+			"data:application/x-ns-proxy-autoconfig;base64,ZnVuY3Rpb24gRmluZFByb3h5Rm9yVVJMKHVybCwgaG9zdCkgewogIHJldHVybiAiUFJPWFkgcHJveHk6ODA4MCI7Cn0K",
+			"function FindProxyForURL(url, host) {\n  return \"PROXY proxy:8080\";\n}\n",
+		},
+		{
+			"URLEncoded",
+			"data:,function%20FindProxyForURL(url%2C%20host)%20%7B%0A%20%20return%20%22PROXY%20proxy%3A8080%22%3B%0A%7D%0A",
+			"function FindProxyForURL(url, host) {\n  return \"PROXY proxy:8080\";\n}\n",
+		},
+	}
 
-func TestDecodeDataURL_URLEncoded(t *testing.T) {
-	uri := "data:,function%20FindProxyForURL(url%2C%20host)%20%7B%0A%20%20return%20%22PROXY%20proxy%3A8080%22%3B%0A%7D%0A"
-	want := "function FindProxyForURL(url, host) {\n  return \"PROXY proxy:8080\";\n}\n"
-	pf := newPACFetcher(uri)
-	assert.Equal(t, want, string(pf.download()))
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pf := newPACFetcher(test.uri)
+			assert.Equal(t, test.expected, string(pf.download()))
+		})
+	}
 }
 
 func TestDecodeDataURL_NonDataScheme(t *testing.T) {


### PR DESCRIPTION
This adds support for reading pac files from [data urls](https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Schemes/data)