### PR TITLE
Update macOS ARM64 and Intel runners to 14 and 15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ 'macos-13', 'ubuntu-22.04', 'ubuntu-22.04-arm', 'windows-2022' ]
+        os: [ 'macos-14', 'ubuntu-22.04', 'ubuntu-22.04-arm', 'windows-2022' ]
         go: [ '1.22' ]
 
     runs-on: ${{ matrix.os }}
@@ -56,10 +56,10 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - os: 'macos-13'
+          - os: 'macos-14-large'
             goos: 'darwin'
             goarch: 'amd64'
-          - os: 'macos-13'
+          - os: 'macos-14'
             goos: 'darwin'
             goarch: 'arm64'
           - os: 'ubuntu-22.04'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - os: 'macos-14-large'
+          - os: 'macos-15-intel'
             goos: 'darwin'
             goarch: 'amd64'
           - os: 'macos-14'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         target:
-          - os: 'macos-14-large'
+          - os: 'macos-15-intel'
             goos: 'darwin'
             goarch: 'amd64'
           - os: 'macos-14'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,10 +32,10 @@ jobs:
     strategy:
       matrix:
         target:
-          - os: 'macos-13'
+          - os: 'macos-14-large'
             goos: 'darwin'
             goarch: 'amd64'
-          - os: 'macos-13'
+          - os: 'macos-14'
             goos: 'darwin'
             goarch: 'arm64'
           - os: 'ubuntu-22.04'


### PR DESCRIPTION
The macOS 13 runners have been shut down. The Intel `macos-14-large` runner
seems to require billing to be set up, so I've moved the Intel builder to
`macos-15-intel` instead. We'll stick to the oldest supported OS version, so
ARM64 builds will happen on macOS 14 for now.

See https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/