### PR TITLE
feat: Add PAC URL auto dicovery on Windows

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,7 @@
 Cam Hutchison <camh@xdna.net>
 Chris Gavin <chrisgavin@outlook.com.au>
 Dave Goddard <dave.goddard@anz.com>
+Hiroaki Mizuguchi <mhiroaki@gmail.com>
 James Moriarty <jamespaulmoriarty@gmail.com>
 Julia Ogris <julia.ogris@gmail.com>
 Keilin Olsen <keilin.olsen@anz.com>

--- a/pacfinder_windows.go
+++ b/pacfinder_windows.go
@@ -1,4 +1,4 @@
-// Copyright 2019, 2021, 2022 The Alpaca Authors
+// Copyright 2019, 2021, 2022, 2026 The Alpaca Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,18 +14,106 @@
 
 package main
 
+import (
+	"log"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
 type pacFinder struct{
 	pacURL string
+	auto   bool
 }
 
 func newPacFinder(pacURL string) *pacFinder {
-	return &pacFinder{pacURL: pacURL}
+	if pacURL != "" {
+		return &pacFinder{pacURL: pacURL, auto: false}
+	}
+
+	_, pacURL, _, _, err := getPACURL()
+	if err != nil {
+		log.Print("Unable to access system network information")
+		return &pacFinder{"", false}
+	}
+	return &pacFinder{pacURL: pacURL, auto: true}
 }
 
 func (finder *pacFinder) findPACURL() (string, error) {
-	return finder.pacURL, nil
+	if !finder.auto {
+		return finder.pacURL, nil
+	}
+	_, pacURL, _, _, err := getPACURL()
+	return pacURL, err
 }
 
 func (finder *pacFinder) pacChanged() bool {
+	if url, _ := finder.findPACURL(); finder.pacURL != url {
+		finder.pacURL = url
+		return true
+	}
 	return false
+}
+
+type BOOL int32
+
+// WINHTTP_CURRENT_USER_IE_PROXY_CONFIG (winhttp.h)
+type winhttpCurrentUserIEProxyConfig struct {
+	// The Internet Explorer proxy configuration for the current user specifies "automatically detect settings".
+	fAutoDetect BOOL
+	// The auto-configuration URL if the Internet Explorer proxy configuration for the current user specifies "Use automatic proxy configuration".
+	lpszAutoConfigUrl *uint16
+	// The proxy URL if the Internet Explorer proxy configuration for the current user specifies "use a proxy server".
+	lpszProxy *uint16
+	// The optional proxy by-pass server list.
+	lpszProxyBypass *uint16
+}
+
+var (
+	modWinHttp     = windows.NewLazySystemDLL("winhttp.dll")
+	procGetCfg     = modWinHttp.NewProc("WinHttpGetIEProxyConfigForCurrentUser")
+	modKernel      = windows.NewLazySystemDLL("kernel32.dll")
+	procGlobalFree = modKernel.NewProc("GlobalFree")
+)
+
+func getPACURL() (autoDetect bool, autoConfigURL string, proxy string, proxyBypass string, err error) {
+	var cfg winhttpCurrentUserIEProxyConfig
+
+	// WINHTTPAPI BOOL WinHttpGetIEProxyConfigForCurrentUser(
+	//  [in, out] WINHTTP_CURRENT_USER_IE_PROXY_CONFIG *pProxyConfig
+	// );
+	r1, _, e := procGetCfg.Call(uintptr(unsafe.Pointer(&cfg)))
+	if r1 == 0 {
+		if e != syscall.Errno(0) {
+			err = e
+		} else {
+			err = syscall.EINVAL
+		}
+		return
+	}
+	defer func() {
+		// if they are non-NULL. Use GlobalFree to free the strings.
+		globalFreeForLPWSTR(cfg.lpszAutoConfigUrl)
+		globalFreeForLPWSTR(cfg.lpszProxy)
+		globalFreeForLPWSTR(cfg.lpszProxyBypass)
+	}()
+
+	autoDetect = cfg.fAutoDetect != 0
+	if cfg.lpszAutoConfigUrl != nil {
+		autoConfigURL = windows.UTF16PtrToString(cfg.lpszAutoConfigUrl)
+	}
+	if cfg.lpszProxy != nil {
+		proxy = windows.UTF16PtrToString(cfg.lpszProxy)
+	}
+	if cfg.lpszProxyBypass != nil {
+		proxyBypass = windows.UTF16PtrToString(cfg.lpszProxyBypass)
+	}
+	return
+}
+
+func globalFreeForLPWSTR(ptr *uint16) {
+	if ptr != nil {
+		procGlobalFree.Call(uintptr(unsafe.Pointer(ptr)))
+	}
 }


### PR DESCRIPTION
This pull request add PAC URL detection on Windows to Use [WinHttpGetIEProxyConfigForCurrentUser](https://learn.microsoft.com/en-us/windows/win32/api/winhttp/nf-winhttp-winhttpgetieproxyconfigforcurrentuser)

### Enable PAC Environment

```console
PS E:\work\alpaca> .\alpaca.exe
2026/01/27 16:39:16.812001 main.go:90: Credentials not found, disabling proxy auth: cannot get user secret from keyring: secret not found in keyring
2026/01/27 16:39:16.846398 pacfetcher.go:146: Attempting to download PAC from http://fedora.mshome.net/proxy.pac
2026/01/27 16:39:16.852945 main.go:115: Listening on tcp6 localhost:3128
2026/01/27 16:39:16.852945 main.go:115: Listening on tcp4 localhost:3128
2026/01/27 16:39:22.099234 proxyfinder.go:113: [1] CONNECT //example.org:443 via "DIRECT"
```

### Disable PAC Environment

```console
PS E:\work\alpaca> .\alpaca.exe
2026/01/27 16:39:41.801847 main.go:90: Credentials not found, disabling proxy auth: cannot get user secret from keyring: secret not found in keyring
2026/01/27 16:39:41.836256 pacfetcher.go:142: No PAC URL specified or detected; all requests will be made directly
2026/01/27 16:39:41.840444 main.go:115: Listening on tcp6 localhost:3128
2026/01/27 16:39:41.840444 main.go:115: Listening on tcp4 localhost:3128
2026/01/27 16:39:48.946685 proxyfinder.go:97: [1] CONNECT //example.org:443 via "DIRECT" (not connected to PAC server)
```