### PR TITLE
Eliminate per-connection 407 probe for known-auth proxies

### DIFF
--- a/main.go
+++ b/main.go
@@ -208,12 +208,7 @@ func createServer(port int, pacurl string, auth *authChain, enableSocks bool) *h
 			blockProxy(host)
 		}
 	})
-	onPACUpdate := func() {
-		proxyHandler.authCache.Range(func(k, _ any) bool {
-			proxyHandler.authCache.Delete(k)
-			return true
-		})
-	}
+	onPACUpdate := proxyHandler.authCache.Clear
 	proxyFinder := NewProxyFinder(pacurl, pacWrapper, enableSocks, onPACUpdate)
 	blockProxy = proxyFinder.blockProxy
 	mux := http.NewServeMux()

--- a/main.go
+++ b/main.go
@@ -200,8 +200,22 @@ func main() {
 
 func createServer(port int, pacurl string, auth *authChain, enableSocks bool) *http.Server {
 	pacWrapper := NewPACWrapper(PACData{Port: port})
-	proxyFinder := NewProxyFinder(pacurl, pacWrapper, enableSocks)
-	proxyHandler := NewProxyHandler(auth, getProxyFromContext, proxyFinder.blockProxy)
+	// Construction order is load-bearing: authCache must exist before
+	// onPACUpdate is captured, and blockProxy before proxyFinder is used.
+	var blockProxy func(string)
+	proxyHandler := NewProxyHandler(auth, getProxyFromContext, func(host string) {
+		if blockProxy != nil {
+			blockProxy(host)
+		}
+	})
+	onPACUpdate := func() {
+		proxyHandler.authCache.Range(func(k, _ any) bool {
+			proxyHandler.authCache.Delete(k)
+			return true
+		})
+	}
+	proxyFinder := NewProxyFinder(pacurl, pacWrapper, enableSocks, onPACUpdate)
+	blockProxy = proxyFinder.blockProxy
 	mux := http.NewServeMux()
 	pacWrapper.SetupHandlers(mux)
 

--- a/main.go
+++ b/main.go
@@ -200,8 +200,9 @@ func main() {
 
 func createServer(port int, pacurl string, auth *authChain, enableSocks bool) *http.Server {
 	pacWrapper := NewPACWrapper(PACData{Port: port})
-	// Construction order is load-bearing: authCache must exist before
-	// onPACUpdate is captured, and blockProxy before proxyFinder is used.
+	// Note that proxyHandler and proxyFinder are mutually dependent:
+	// proxyHandler calls proxyFinder.blockProxy(), and proxyFinder calls
+	// proxyHandler.authCache.Clear().
 	var blockProxy func(string)
 	proxyHandler := NewProxyHandler(auth, getProxyFromContext, func(host string) {
 		if blockProxy != nil {

--- a/multiauth_integration_test.go
+++ b/multiauth_integration_test.go
@@ -405,7 +405,8 @@ func TestConnectViaProxy_FallsThroughOn407(t *testing.T) {
 	require.NoError(t, err)
 	req.Host = "example.com:443"
 
-	conn, err := connectViaProxy(req, proxy.URL(), chain, &sync.Map{})
+	ph := NewProxyHandler(chain, nil, func(string) {})
+	conn, err := ph.connectViaProxy(req, proxy.URL())
 	require.NoError(t, err)
 	defer conn.Close() //nolint:errcheck //nolint:errcheck
 
@@ -433,7 +434,8 @@ func TestConnectViaProxy_RefusesBasicDowngrade(t *testing.T) {
 	require.NoError(t, err)
 	req.Host = "example.com:443"
 
-	_, err = connectViaProxy(req, proxy.URL(), chain, &sync.Map{})
+	ph2 := NewProxyHandler(chain, nil, func(string) {})
+	_, err = ph2.connectViaProxy(req, proxy.URL())
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errNoMatchingAuthMethod)
 }

--- a/multiauth_integration_test.go
+++ b/multiauth_integration_test.go
@@ -405,7 +405,7 @@ func TestConnectViaProxy_FallsThroughOn407(t *testing.T) {
 	require.NoError(t, err)
 	req.Host = "example.com:443"
 
-	conn, err := connectViaProxy(req, proxy.URL(), chain)
+	conn, err := connectViaProxy(req, proxy.URL(), chain, &sync.Map{})
 	require.NoError(t, err)
 	defer conn.Close() //nolint:errcheck //nolint:errcheck
 
@@ -433,7 +433,7 @@ func TestConnectViaProxy_RefusesBasicDowngrade(t *testing.T) {
 	require.NoError(t, err)
 	req.Host = "example.com:443"
 
-	_, err = connectViaProxy(req, proxy.URL(), chain)
+	_, err = connectViaProxy(req, proxy.URL(), chain, &sync.Map{})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errNoMatchingAuthMethod)
 }

--- a/proxy.go
+++ b/proxy.go
@@ -415,6 +415,7 @@ func connectViaProxy(req *http.Request, proxyURL *url.URL, auth *authChain,
 				log.Printf("[%d] Got %q response, retrying with auth", id, resp2.Status)
 				schemes := parseProxyAuthenticateSchemes(resp2.Header)
 				_ = resp2.Body.Close()
+				authCache.Store(proxyURL.Host, proxyAuthInfo{schemes: schemes})
 				authResp2, err := retryConnectWithAuth(req, proxyURL, auth, schemes, &tr2)
 				if err != nil {
 					return nil, err

--- a/proxy.go
+++ b/proxy.go
@@ -222,6 +222,7 @@ func splitChallengeNames(value string) []string {
 }
 
 type proxyAuthInfo struct {
+	// schemes are lower-cased, matching parseProxyAuthenticateSchemes output.
 	schemes []string
 }
 

--- a/proxy.go
+++ b/proxy.go
@@ -277,7 +277,7 @@ func (ph ProxyHandler) handleConnect(w http.ResponseWriter, req *http.Request) {
 	if proxyURL == nil {
 		server, err = connectDirect(req)
 	} else {
-		server, err = connectViaProxy(req, proxyURL, ph.auth, ph.authCache)
+		server, err = ph.connectViaProxy(req, proxyURL)
 		var oe *net.OpError
 		if errors.As(err, &oe) && oe.Op == "proxyconnect" {
 			log.Printf("[%d] Temporarily blocking proxy: %q", id, proxyURL.Host)
@@ -352,8 +352,40 @@ func connectDirect(req *http.Request) (net.Conn, error) {
 	return server, err
 }
 
-func connectViaProxy(req *http.Request, proxyURL *url.URL, auth *authChain,
-	authCache *sync.Map) (net.Conn, error) {
+// coldProbe dials proxyURL on tr, sends an unauthenticated CONNECT, and handles
+// the 407 response by caching the advertised schemes and retrying with auth.
+// The caller is responsible for deferring tr.Close().
+func coldProbe(req *http.Request, proxyURL *url.URL, auth *authChain,
+	tr *transport, authCache *sync.Map) (*http.Response, error) {
+	id := req.Context().Value(contextKeyID)
+	if err := tr.dial(proxyURL); err != nil {
+		log.Printf("[%d] Error dialling proxy %s: %v", id, proxyURL.Host, err)
+		return nil, err
+	}
+	req.Header.Del("Proxy-Authorization")
+	resp, err := tr.RoundTrip(req)
+	if err != nil {
+		log.Printf("[%d] Error reading CONNECT response: %v", id, err)
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusProxyAuthRequired || auth == nil {
+		return resp, nil
+	}
+	log.Printf("[%d] Got %q response, retrying with auth", id, resp.Status)
+	schemes := parseProxyAuthenticateSchemes(resp.Header)
+	_ = resp.Body.Close()
+	authResp, err := retryConnectWithAuth(req, proxyURL, auth, schemes, tr)
+	if err != nil {
+		return nil, err
+	}
+	if authResp.StatusCode != http.StatusProxyAuthRequired {
+		authCache.Store(proxyURL.Host, proxyAuthInfo{schemes: schemes})
+	}
+	log.Printf("[%d] Got %q response", id, authResp.Status)
+	return authResp, nil
+}
+
+func (ph *ProxyHandler) connectViaProxy(req *http.Request, proxyURL *url.URL) (net.Conn, error) {
 	id := req.Context().Value(contextKeyID)
 
 	// SOCKS5 short-circuit: SOCKS5 has its own authentication model
@@ -388,74 +420,35 @@ func connectViaProxy(req *http.Request, proxyURL *url.URL, auth *authChain,
 	activeTr := &tr // points to the transport holding the live tunnel
 
 	var resp *http.Response
-	if cached, ok := authCache.Load(proxyURL.Host); ok && auth != nil {
-		// Phase 1: cache hit — skip unauthenticated probe.
+	if cached, ok := ph.authCache.Load(proxyURL.Host); ok && ph.auth != nil {
+		// Cache hit — skip unauthenticated probe.
 		info := cached.(proxyAuthInfo)
-		authResp, err := retryConnectWithAuth(req, proxyURL, auth, info.schemes, &tr)
+		authResp, err := retryConnectWithAuth(req, proxyURL, ph.auth, info.schemes, &tr)
 		if err != nil {
 			return nil, err
 		}
 		if authResp.StatusCode == http.StatusProxyAuthRequired {
 			// Stale cache entry — evict and fall through to cold probe.
-			authCache.Delete(proxyURL.Host)
+			ph.authCache.Delete(proxyURL.Host)
 			_ = authResp.Body.Close()
 			tr2 := transport{}
 			defer tr2.Close() //nolint:errcheck
 			activeTr = &tr2
-			if err := tr2.dial(proxyURL); err != nil {
-				log.Printf("[%d] Error dialling proxy %s: %v", id, proxyURL.Host, err)
-				return nil, err
-			}
-			req.Header.Del("Proxy-Authorization")
-			resp2, err := tr2.RoundTrip(req)
+			var err error
+			resp, err = coldProbe(req, proxyURL, ph.auth, &tr2, ph.authCache)
 			if err != nil {
-				log.Printf("[%d] Error reading CONNECT response: %v", id, err)
 				return nil, err
-			}
-			if resp2.StatusCode == http.StatusProxyAuthRequired && auth != nil {
-				log.Printf("[%d] Got %q response, retrying with auth", id, resp2.Status)
-				schemes := parseProxyAuthenticateSchemes(resp2.Header)
-				_ = resp2.Body.Close()
-				authResp2, err := retryConnectWithAuth(req, proxyURL, auth, schemes, &tr2)
-				if err != nil {
-					return nil, err
-				}
-				if authResp2.StatusCode != http.StatusProxyAuthRequired {
-					authCache.Store(proxyURL.Host, proxyAuthInfo{schemes: schemes})
-				}
-				log.Printf("[%d] Got %q response", id, authResp2.Status)
-				resp = authResp2
-			} else {
-				resp = resp2
 			}
 		} else {
 			log.Printf("[%d] Got %q response", id, authResp.Status)
 			resp = authResp
 		}
 	} else {
-		// Phase 2: cold probe — no cached entry.
-		if err := tr.dial(proxyURL); err != nil {
-			log.Printf("[%d] Error dialling proxy %s: %v", id, proxyURL.Host, err)
-			return nil, err
-		}
+		// Cold probe — no cached entry; populate cache on first 407.
 		var err error
-		resp, err = tr.RoundTrip(req)
+		resp, err = coldProbe(req, proxyURL, ph.auth, &tr, ph.authCache)
 		if err != nil {
-			log.Printf("[%d] Error reading CONNECT response: %v", id, err)
 			return nil, err
-		}
-		if resp.StatusCode == http.StatusProxyAuthRequired && auth != nil {
-			log.Printf("[%d] Got %q response, retrying with auth", id, resp.Status)
-			schemes := parseProxyAuthenticateSchemes(resp.Header)
-			_ = resp.Body.Close()
-			authCache.Store(proxyURL.Host, proxyAuthInfo{schemes: schemes})
-			// resp is now stale; the retry helper returns a fresh one.
-			authResp, err := retryConnectWithAuth(req, proxyURL, auth, schemes, &tr)
-			if err != nil {
-				return nil, err
-			}
-			log.Printf("[%d] Got %q response", id, authResp.Status)
-			resp = authResp
 		}
 	}
 	_ = resp.Body.Close()

--- a/proxy.go
+++ b/proxy.go
@@ -417,8 +417,6 @@ func (ph *ProxyHandler) connectViaProxy(req *http.Request, proxyURL *url.URL) (n
 
 	var tr transport
 	defer tr.Close() //nolint:errcheck
-	activeTr := &tr // points to the transport holding the live tunnel
-
 	var resp *http.Response
 	if cached, ok := ph.authCache.Load(proxyURL.Host); ok && ph.auth != nil {
 		// Cache hit — skip unauthenticated probe.
@@ -449,7 +447,7 @@ func (ph *ProxyHandler) connectViaProxy(req *http.Request, proxyURL *url.URL) (n
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("[%d] Unexpected response status: %s", id, resp.Status)
 	}
-	return activeTr.hijack(), nil
+	return tr.hijack(), nil
 }
 
 // retryConnectWithAuth iterates the configured auth chain over a CONNECT

--- a/proxy.go
+++ b/proxy.go
@@ -134,7 +134,7 @@ func isToken(s string) bool {
 
 // parseProxyAuthenticateSchemes returns the deduplicated, lower-cased
 // scheme names from a 407 response's Proxy-Authenticate header(s),
-// preserving the order in which they appeared. RFC 7235 §4.3 allows
+// preserving the order in which they appeared. RFC 9110 §11.3 allows
 // either multiple Proxy-Authenticate header fields OR a single header
 // field containing a comma-separated list of challenges (RFC 7230 list
 // extension), so we honour both. The portion after the scheme token
@@ -158,11 +158,11 @@ func parseProxyAuthenticateSchemes(header http.Header) []string {
 
 // splitChallengeNames extracts the scheme names from a single
 // Proxy-Authenticate header field value that may contain multiple
-// challenges joined by commas (RFC 7235 §4.3 + RFC 7230 §7 list
+// challenges joined by commas (RFC 9110 §11.3 + RFC 7230 §7 list
 // extension). It walks the value byte-by-byte so that commas inside
 // quoted-strings are not treated as challenge separators.
 //
-// RFC 7235's challenge grammar is:
+// RFC 9110's challenge grammar is:
 //
 //	challenge = auth-scheme [ 1*SP ( token68 /
 //	    [ ( "," / auth-param ) *( OWS "," [ OWS auth-param ] ) ] ) ]
@@ -179,7 +179,7 @@ func parseProxyAuthenticateSchemes(header http.Header) []string {
 // will cause `bar` to be misclassified as a scheme name. This is benign
 // because no real authenticator's scheme() returns `bar`, so the picker
 // silently ignores it. We accept this rather than implementing full
-// RFC 7235 grammar parsing for the tail of unparseable proxies.
+// RFC 9110 grammar parsing for the tail of unparseable proxies.
 //
 // The returned strings are the raw auth-scheme tokens; the caller
 // validates them via isToken.

--- a/proxy.go
+++ b/proxy.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 
 	"golang.org/x/net/proxy"
 )
@@ -220,17 +221,22 @@ func splitChallengeNames(value string) []string {
 	return names
 }
 
+type proxyAuthInfo struct {
+	schemes []string
+}
+
 type ProxyHandler struct {
 	transport *http.Transport
 	auth      *authChain
 	block     func(string)
+	authCache *sync.Map
 }
 
 type proxyFunc func(*http.Request) (*url.URL, error)
 
 func NewProxyHandler(auth *authChain, proxy proxyFunc, block func(string)) ProxyHandler {
 	tr := &http.Transport{Proxy: proxy, TLSClientConfig: tlsClientConfig}
-	return ProxyHandler{tr, auth, block}
+	return ProxyHandler{tr, auth, block, &sync.Map{}}
 }
 
 func (ph ProxyHandler) WrapHandler(next http.Handler) http.Handler {
@@ -270,7 +276,7 @@ func (ph ProxyHandler) handleConnect(w http.ResponseWriter, req *http.Request) {
 	if proxyURL == nil {
 		server, err = connectDirect(req)
 	} else {
-		server, err = connectViaProxy(req, proxyURL, ph.auth)
+		server, err = connectViaProxy(req, proxyURL, ph.auth, ph.authCache)
 		var oe *net.OpError
 		if errors.As(err, &oe) && oe.Op == "proxyconnect" {
 			log.Printf("[%d] Temporarily blocking proxy: %q", id, proxyURL.Host)
@@ -345,7 +351,8 @@ func connectDirect(req *http.Request) (net.Conn, error) {
 	return server, err
 }
 
-func connectViaProxy(req *http.Request, proxyURL *url.URL, auth *authChain) (net.Conn, error) {
+func connectViaProxy(req *http.Request, proxyURL *url.URL, auth *authChain,
+	authCache *sync.Map) (net.Conn, error) {
 	id := req.Context().Value(contextKeyID)
 
 	// SOCKS5 short-circuit: SOCKS5 has its own authentication model
@@ -377,26 +384,75 @@ func connectViaProxy(req *http.Request, proxyURL *url.URL, auth *authChain) (net
 
 	var tr transport
 	defer tr.Close() //nolint:errcheck
-	if err := tr.dial(proxyURL); err != nil {
-		log.Printf("[%d] Error dialling proxy %s: %v", id, proxyURL.Host, err)
-		return nil, err
-	}
-	resp, err := tr.RoundTrip(req)
-	if err != nil {
-		log.Printf("[%d] Error reading CONNECT response: %v", id, err)
-		return nil, err
-	}
-	if resp.StatusCode == http.StatusProxyAuthRequired && auth != nil {
-		log.Printf("[%d] Got %q response, retrying with auth", id, resp.Status)
-		schemes := parseProxyAuthenticateSchemes(resp.Header)
-		_ = resp.Body.Close()
-		// resp is now stale; the retry helper returns a fresh one.
-		authResp, err := retryConnectWithAuth(req, proxyURL, auth, schemes, &tr)
+	activeTr := &tr // points to the transport holding the live tunnel
+
+	var resp *http.Response
+	if cached, ok := authCache.Load(proxyURL.Host); ok && auth != nil {
+		// Phase 1: cache hit — skip unauthenticated probe.
+		info := cached.(proxyAuthInfo)
+		authResp, err := retryConnectWithAuth(req, proxyURL, auth, info.schemes, &tr)
 		if err != nil {
 			return nil, err
 		}
-		log.Printf("[%d] Got %q response", id, authResp.Status)
-		resp = authResp
+		if authResp.StatusCode == http.StatusProxyAuthRequired {
+			// Stale cache entry — evict and fall through to cold probe.
+			authCache.Delete(proxyURL.Host)
+			_ = authResp.Body.Close()
+			tr2 := transport{}
+			defer tr2.Close() //nolint:errcheck
+			activeTr = &tr2
+			if err := tr2.dial(proxyURL); err != nil {
+				log.Printf("[%d] Error dialling proxy %s: %v", id, proxyURL.Host, err)
+				return nil, err
+			}
+			req.Header.Del("Proxy-Authorization")
+			resp2, err := tr2.RoundTrip(req)
+			if err != nil {
+				log.Printf("[%d] Error reading CONNECT response: %v", id, err)
+				return nil, err
+			}
+			if resp2.StatusCode == http.StatusProxyAuthRequired && auth != nil {
+				log.Printf("[%d] Got %q response, retrying with auth", id, resp2.Status)
+				schemes := parseProxyAuthenticateSchemes(resp2.Header)
+				_ = resp2.Body.Close()
+				authResp2, err := retryConnectWithAuth(req, proxyURL, auth, schemes, &tr2)
+				if err != nil {
+					return nil, err
+				}
+				log.Printf("[%d] Got %q response", id, authResp2.Status)
+				resp = authResp2
+			} else {
+				resp = resp2
+			}
+		} else {
+			log.Printf("[%d] Got %q response", id, authResp.Status)
+			resp = authResp
+		}
+	} else {
+		// Phase 2: cold probe — no cached entry.
+		if err := tr.dial(proxyURL); err != nil {
+			log.Printf("[%d] Error dialling proxy %s: %v", id, proxyURL.Host, err)
+			return nil, err
+		}
+		var err error
+		resp, err = tr.RoundTrip(req)
+		if err != nil {
+			log.Printf("[%d] Error reading CONNECT response: %v", id, err)
+			return nil, err
+		}
+		if resp.StatusCode == http.StatusProxyAuthRequired && auth != nil {
+			log.Printf("[%d] Got %q response, retrying with auth", id, resp.Status)
+			schemes := parseProxyAuthenticateSchemes(resp.Header)
+			_ = resp.Body.Close()
+			authCache.Store(proxyURL.Host, proxyAuthInfo{schemes: schemes})
+			// resp is now stale; the retry helper returns a fresh one.
+			authResp, err := retryConnectWithAuth(req, proxyURL, auth, schemes, &tr)
+			if err != nil {
+				return nil, err
+			}
+			log.Printf("[%d] Got %q response", id, authResp.Status)
+			resp = authResp
+		}
 	}
 	_ = resp.Body.Close()
 	if resp.StatusCode == http.StatusProxyAuthRequired {
@@ -406,7 +462,7 @@ func connectViaProxy(req *http.Request, proxyURL *url.URL, auth *authChain) (net
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("[%d] Unexpected response status: %s", id, resp.Status)
 	}
-	return tr.hijack(), nil
+	return activeTr.hijack(), nil
 }
 
 // retryConnectWithAuth iterates the configured auth chain over a CONNECT

--- a/proxy.go
+++ b/proxy.go
@@ -416,13 +416,12 @@ func connectViaProxy(req *http.Request, proxyURL *url.URL, auth *authChain,
 				log.Printf("[%d] Got %q response, retrying with auth", id, resp2.Status)
 				schemes := parseProxyAuthenticateSchemes(resp2.Header)
 				_ = resp2.Body.Close()
-				// Store before attempting: the proxy advertised these schemes, so cache
-				// them now. If re-auth fails the next request skips the bare probe and
-				// evicts on a fresh 407 — same path as any stale entry.
-				authCache.Store(proxyURL.Host, proxyAuthInfo{schemes: schemes})
 				authResp2, err := retryConnectWithAuth(req, proxyURL, auth, schemes, &tr2)
 				if err != nil {
 					return nil, err
+				}
+				if authResp2.StatusCode != http.StatusProxyAuthRequired {
+					authCache.Store(proxyURL.Host, proxyAuthInfo{schemes: schemes})
 				}
 				log.Printf("[%d] Got %q response", id, authResp2.Status)
 				resp = authResp2

--- a/proxy.go
+++ b/proxy.go
@@ -415,6 +415,9 @@ func connectViaProxy(req *http.Request, proxyURL *url.URL, auth *authChain,
 				log.Printf("[%d] Got %q response, retrying with auth", id, resp2.Status)
 				schemes := parseProxyAuthenticateSchemes(resp2.Header)
 				_ = resp2.Body.Close()
+				// Store before attempting: the proxy advertised these schemes, so cache
+				// them now. If re-auth fails the next request skips the bare probe and
+				// evicts on a fresh 407 — same path as any stale entry.
 				authCache.Store(proxyURL.Host, proxyAuthInfo{schemes: schemes})
 				authResp2, err := retryConnectWithAuth(req, proxyURL, auth, schemes, &tr2)
 				if err != nil {

--- a/proxy.go
+++ b/proxy.go
@@ -428,21 +428,11 @@ func (ph *ProxyHandler) connectViaProxy(req *http.Request, proxyURL *url.URL) (n
 			return nil, err
 		}
 		if authResp.StatusCode == http.StatusProxyAuthRequired {
-			// Stale cache entry — evict and fall through to cold probe.
+			// Stale or invalid cache entry — evict and return error.
 			ph.authCache.Delete(proxyURL.Host)
-			_ = authResp.Body.Close()
-			tr2 := transport{}
-			defer tr2.Close() //nolint:errcheck
-			activeTr = &tr2
-			var err error
-			resp, err = coldProbe(req, proxyURL, ph.auth, &tr2, ph.authCache)
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			log.Printf("[%d] Got %q response", id, authResp.Status)
-			resp = authResp
 		}
+		log.Printf("[%d] Got %q response", id, authResp.Status)
+		resp = authResp
 	} else {
 		// Cold probe — no cached entry; populate cache on first 407.
 		var err error

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -435,6 +435,7 @@ type authCacheMockProxy struct {
 	bareConnects   int
 	authedConnects int
 	respondWith407 bool
+	stale407Once   bool
 }
 
 func (m *authCacheMockProxy) ServeHTTP(w http.ResponseWriter, req *http.Request) {
@@ -449,8 +450,9 @@ func (m *authCacheMockProxy) ServeHTTP(w http.ResponseWriter, req *http.Request)
 	} else {
 		m.bareConnects++
 	}
+	isFirstBare := m.stale407Once && !hasAuth && m.bareConnects == 1
 	m.mu.Unlock()
-	if m.respondWith407 || !hasAuth {
+	if m.respondWith407 || isFirstBare || !hasAuth {
 		w.Header().Set("Proxy-Authenticate", "Basic realm=\"proxy\"")
 		w.WriteHeader(http.StatusProxyAuthRequired)
 		return
@@ -467,6 +469,14 @@ func (m *authCacheMockProxy) counts() (bare, authed int) {
 func newAuthCacheTestProxy(t *testing.T, respondWith407 bool) (*httptest.Server, *authCacheMockProxy) {
 	t.Helper()
 	mock := &authCacheMockProxy{respondWith407: respondWith407}
+	srv := httptest.NewServer(mock)
+	t.Cleanup(srv.Close)
+	return srv, mock
+}
+
+func newStaleOnceTestProxy(t *testing.T) (*httptest.Server, *authCacheMockProxy) {
+	t.Helper()
+	mock := &authCacheMockProxy{stale407Once: true}
 	srv := httptest.NewServer(mock)
 	t.Cleanup(srv.Close)
 	return srv, mock
@@ -534,4 +544,20 @@ func TestConnectAuthCache_EvictsOnStale407(t *testing.T) {
 	assert.False(t, stillCached, "stale cache entry must be evicted after a persistent 407")
 	bare, _ := mock.counts()
 	assert.GreaterOrEqual(t, bare, 1, "a bare probe must be attempted after cache eviction")
+}
+
+func TestConnectAuthCache_EvictsOnStale407_ThenSucceeds(t *testing.T) {
+	proxySrv, mock := newStaleOnceTestProxy(t)
+	proxyURL, err := url.Parse(proxySrv.URL)
+	require.NoError(t, err)
+	auth := newAuthChain(newBasicAuthenticator("user:pass"))
+	cache := &sync.Map{}
+	cache.Store(proxyURL.Host, proxyAuthInfo{schemes: []string{"Basic"}})
+	req := makeConnectReq(t)
+	conn, err := connectViaProxy(req, proxyURL, auth, cache)
+	require.NoError(t, err, "should succeed after stale eviction and cold probe")
+	require.NotNil(t, conn, "connection must be non-nil on success")
+	conn.Close()
+	bare, _ := mock.counts()
+	assert.GreaterOrEqual(t, bare, 1, "cold probe must fire after eviction")
 }

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -26,6 +26,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -425,4 +426,112 @@ func TestSOCKS5Proxy(t *testing.T) {
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	assert.Equal(t, "/testpath", string(body))
+}
+
+// Auth-cache unit tests — covers proxyAuthInfo / authCache behaviour in connectViaProxy.
+
+type authCacheMockProxy struct {
+	mu             sync.Mutex
+	bareConnects   int
+	authedConnects int
+	respondWith407 bool
+}
+
+func (m *authCacheMockProxy) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodConnect {
+		http.Error(w, "only CONNECT supported", http.StatusMethodNotAllowed)
+		return
+	}
+	hasAuth := req.Header.Get("Proxy-Authorization") != ""
+	m.mu.Lock()
+	if hasAuth {
+		m.authedConnects++
+	} else {
+		m.bareConnects++
+	}
+	m.mu.Unlock()
+	if m.respondWith407 || !hasAuth {
+		w.Header().Set("Proxy-Authenticate", "Basic realm=\"proxy\"")
+		w.WriteHeader(http.StatusProxyAuthRequired)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func (m *authCacheMockProxy) counts() (bare, authed int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.bareConnects, m.authedConnects
+}
+
+func newAuthCacheTestProxy(t *testing.T, respondWith407 bool) (*httptest.Server, *authCacheMockProxy) {
+	t.Helper()
+	mock := &authCacheMockProxy{respondWith407: respondWith407}
+	srv := httptest.NewServer(mock)
+	t.Cleanup(srv.Close)
+	return srv, mock
+}
+
+func makeConnectReq(t *testing.T) *http.Request {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodConnect, "https://target.example.com:443", nil)
+	require.NoError(t, err)
+	req.Host = "target.example.com:443"
+	return req
+}
+
+func TestConnectAuthCache_PopulatesOnFirst407(t *testing.T) {
+	proxySrv, mock := newAuthCacheTestProxy(t, false)
+	proxyURL, err := url.Parse(proxySrv.URL)
+	require.NoError(t, err)
+	auth := newAuthChain(newBasicAuthenticator("user:pass"))
+	cache := &sync.Map{}
+	req := makeConnectReq(t)
+	conn, err := connectViaProxy(req, proxyURL, auth, cache)
+	require.NoError(t, err)
+	if conn != nil {
+		conn.Close()
+	}
+	bare, _ := mock.counts()
+	assert.Equal(t, 1, bare, "expected exactly one unauthenticated probe")
+	val, ok := cache.Load(proxyURL.Host)
+	require.True(t, ok, "authCache must have an entry for the proxy host after a 407")
+	info, ok := val.(proxyAuthInfo)
+	require.True(t, ok, "cached value must be of type proxyAuthInfo")
+	assert.NotEmpty(t, info.schemes, "cached schemes must not be empty")
+	assert.Contains(t, info.schemes, "basic", "Basic scheme must be recorded in the cache")
+}
+
+func TestConnectAuthCache_SkipsProbeOnCacheHit(t *testing.T) {
+	proxySrv, mock := newAuthCacheTestProxy(t, false)
+	proxyURL, err := url.Parse(proxySrv.URL)
+	require.NoError(t, err)
+	auth := newAuthChain(newBasicAuthenticator("user:pass"))
+	cache := &sync.Map{}
+	cache.Store(proxyURL.Host, proxyAuthInfo{schemes: []string{"Basic"}})
+	req := makeConnectReq(t)
+	conn, err := connectViaProxy(req, proxyURL, auth, cache)
+	require.NoError(t, err)
+	if conn != nil {
+		conn.Close()
+	}
+	bare, authed := mock.counts()
+	assert.Equal(t, 0, bare, "cache hit must suppress the unauthenticated probe")
+	assert.Equal(t, 1, authed, "expected exactly one authenticated CONNECT")
+}
+
+func TestConnectAuthCache_EvictsOnStale407(t *testing.T) {
+	proxySrv, mock := newAuthCacheTestProxy(t, true)
+	proxyURL, err := url.Parse(proxySrv.URL)
+	require.NoError(t, err)
+	auth := newAuthChain(newBasicAuthenticator("user:pass"))
+	cache := &sync.Map{}
+	cache.Store(proxyURL.Host, proxyAuthInfo{schemes: []string{"Basic"}})
+	req := makeConnectReq(t)
+	_, err = connectViaProxy(req, proxyURL, auth, cache)
+	assert.Error(t, err, "should fail when the proxy rejects all auth attempts")
+	_, stillCached := cache.Load(proxyURL.Host)
+	assert.False(t, stillCached, "stale cache entry must be evicted after a persistent 407")
+	bare, _ := mock.counts()
+	assert.GreaterOrEqual(t, bare, 1, "a bare probe must be attempted after cache eviction")
 }

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -518,7 +518,7 @@ func TestConnectAuthCache_SkipsProbeOnCacheHit(t *testing.T) {
 	require.NoError(t, err)
 	auth := newAuthChain(newBasicAuthenticator("user:pass"))
 	cache := &sync.Map{}
-	cache.Store(proxyURL.Host, proxyAuthInfo{schemes: []string{"Basic"}})
+	cache.Store(proxyURL.Host, proxyAuthInfo{schemes: []string{"basic"}})
 	req := makeConnectReq(t)
 	conn, err := connectViaProxy(req, proxyURL, auth, cache)
 	require.NoError(t, err)
@@ -536,14 +536,14 @@ func TestConnectAuthCache_EvictsOnStale407(t *testing.T) {
 	require.NoError(t, err)
 	auth := newAuthChain(newBasicAuthenticator("user:pass"))
 	cache := &sync.Map{}
-	cache.Store(proxyURL.Host, proxyAuthInfo{schemes: []string{"Basic"}})
+	cache.Store(proxyURL.Host, proxyAuthInfo{schemes: []string{"basic"}})
 	req := makeConnectReq(t)
 	_, err = connectViaProxy(req, proxyURL, auth, cache)
 	assert.Error(t, err, "should fail when the proxy rejects all auth attempts")
 	_, stillCached := cache.Load(proxyURL.Host)
 	assert.False(t, stillCached, "stale cache entry must be evicted after a persistent 407")
 	bare, _ := mock.counts()
-	assert.GreaterOrEqual(t, bare, 1, "a bare probe must be attempted after cache eviction")
+	assert.Equal(t, 1, bare, "exactly one bare probe must be attempted after cache eviction")
 }
 
 func TestConnectAuthCache_EvictsOnStale407_ThenSucceeds(t *testing.T) {
@@ -552,14 +552,21 @@ func TestConnectAuthCache_EvictsOnStale407_ThenSucceeds(t *testing.T) {
 	require.NoError(t, err)
 	auth := newAuthChain(newBasicAuthenticator("user:pass"))
 	cache := &sync.Map{}
-	cache.Store(proxyURL.Host, proxyAuthInfo{schemes: []string{"Basic"}})
+	cache.Store(proxyURL.Host, proxyAuthInfo{schemes: []string{"basic"}})
 	req := makeConnectReq(t)
 	conn, err := connectViaProxy(req, proxyURL, auth, cache)
 	require.NoError(t, err, "should succeed after stale eviction and cold probe")
 	require.NotNil(t, conn, "connection must be non-nil on success")
 	conn.Close()
 	bare, _ := mock.counts()
-	assert.GreaterOrEqual(t, bare, 1, "cold probe must fire after eviction")
+	assert.Equal(t, 1, bare, "exactly one bare probe must fire after stale eviction")
+	val, repopulated := cache.Load(proxyURL.Host)
+	assert.True(t, repopulated, "cache must be repopulated after successful stale re-auth")
+	if repopulated {
+		info, ok := val.(proxyAuthInfo)
+		require.True(t, ok)
+		assert.NotEmpty(t, info.schemes, "repopulated cache entry must have schemes")
+	}
 }
 
 func TestConnectAuthCache_NoProbeOnSecondRequest(t *testing.T) {

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -561,3 +561,34 @@ func TestConnectAuthCache_EvictsOnStale407_ThenSucceeds(t *testing.T) {
 	bare, _ := mock.counts()
 	assert.GreaterOrEqual(t, bare, 1, "cold probe must fire after eviction")
 }
+
+func TestConnectAuthCache_NoProbeOnSecondRequest(t *testing.T) {
+	proxySrv, mock := newAuthCacheTestProxy(t, false)
+	proxyURL, err := url.Parse(proxySrv.URL)
+	require.NoError(t, err)
+	auth := newAuthChain(newBasicAuthenticator("user:pass"))
+	cache := &sync.Map{}
+
+	// Pass 1: cold path — cache is empty, proxy will issue a 407 probe.
+	req1 := makeConnectReq(t)
+	conn1, err := connectViaProxy(req1, proxyURL, auth, cache)
+	require.NoError(t, err, "pass 1 must succeed")
+	require.NotNil(t, conn1, "pass 1 connection must be non-nil")
+	conn1.Close()
+
+	bare, _ := mock.counts()
+	assert.Equal(t, 1, bare, "exactly one bare probe expected after pass 1")
+	_, cached := cache.Load(proxyURL.Host)
+	assert.True(t, cached, "cache must have an entry for the proxy host after pass 1")
+
+	// Pass 2: warm path — cache hit must suppress the bare probe entirely.
+	req2 := makeConnectReq(t)
+	conn2, err := connectViaProxy(req2, proxyURL, auth, cache)
+	require.NoError(t, err, "pass 2 must succeed")
+	require.NotNil(t, conn2, "pass 2 connection must be non-nil")
+	conn2.Close()
+
+	bare, authed := mock.counts()
+	assert.Equal(t, 1, bare, "bare probe count must remain 1 after pass 2 (no new probe)")
+	assert.Equal(t, 2, authed, "both passes must have used authenticated CONNECT")
+}

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -486,7 +486,7 @@ func makeConnectReq(t *testing.T) *http.Request {
 	t.Helper()
 	req, err := http.NewRequest(http.MethodConnect, "https://target.example.com:443", nil)
 	require.NoError(t, err)
-	req.Host = "target.example.com:443"
+	req.Host = req.URL.Host
 	return req
 }
 
@@ -497,7 +497,8 @@ func TestConnectAuthCache_PopulatesOnFirst407(t *testing.T) {
 	auth := newAuthChain(newBasicAuthenticator("user:pass"))
 	cache := &sync.Map{}
 	req := makeConnectReq(t)
-	conn, err := connectViaProxy(req, proxyURL, auth, cache)
+	ph := ProxyHandler{auth: auth, authCache: cache}
+	conn, err := ph.connectViaProxy(req, proxyURL)
 	require.NoError(t, err)
 	if conn != nil {
 		conn.Close()
@@ -520,7 +521,8 @@ func TestConnectAuthCache_SkipsProbeOnCacheHit(t *testing.T) {
 	cache := &sync.Map{}
 	cache.Store(proxyURL.Host, proxyAuthInfo{schemes: []string{"basic"}})
 	req := makeConnectReq(t)
-	conn, err := connectViaProxy(req, proxyURL, auth, cache)
+	ph := ProxyHandler{auth: auth, authCache: cache}
+	conn, err := ph.connectViaProxy(req, proxyURL)
 	require.NoError(t, err)
 	if conn != nil {
 		conn.Close()
@@ -538,7 +540,8 @@ func TestConnectAuthCache_EvictsOnStale407(t *testing.T) {
 	cache := &sync.Map{}
 	cache.Store(proxyURL.Host, proxyAuthInfo{schemes: []string{"basic"}})
 	req := makeConnectReq(t)
-	_, err = connectViaProxy(req, proxyURL, auth, cache)
+	ph := ProxyHandler{auth: auth, authCache: cache}
+	_, err = ph.connectViaProxy(req, proxyURL)
 	assert.Error(t, err, "should fail when the proxy rejects all auth attempts")
 	_, stillCached := cache.Load(proxyURL.Host)
 	assert.False(t, stillCached, "stale cache entry must be evicted after a persistent 407")
@@ -554,7 +557,8 @@ func TestConnectAuthCache_EvictsOnStale407_ThenSucceeds(t *testing.T) {
 	cache := &sync.Map{}
 	cache.Store(proxyURL.Host, proxyAuthInfo{schemes: []string{"basic"}})
 	req := makeConnectReq(t)
-	conn, err := connectViaProxy(req, proxyURL, auth, cache)
+	ph := ProxyHandler{auth: auth, authCache: cache}
+	conn, err := ph.connectViaProxy(req, proxyURL)
 	require.NoError(t, err, "should succeed after stale eviction and cold probe")
 	require.NotNil(t, conn, "connection must be non-nil on success")
 	conn.Close()
@@ -577,8 +581,9 @@ func TestConnectAuthCache_NoProbeOnSecondRequest(t *testing.T) {
 	cache := &sync.Map{}
 
 	// Pass 1: cold path — cache is empty, proxy will issue a 407 probe.
+	ph := ProxyHandler{auth: auth, authCache: cache}
 	req1 := makeConnectReq(t)
-	conn1, err := connectViaProxy(req1, proxyURL, auth, cache)
+	conn1, err := ph.connectViaProxy(req1, proxyURL)
 	require.NoError(t, err, "pass 1 must succeed")
 	require.NotNil(t, conn1, "pass 1 connection must be non-nil")
 	conn1.Close()
@@ -590,7 +595,7 @@ func TestConnectAuthCache_NoProbeOnSecondRequest(t *testing.T) {
 
 	// Pass 2: warm path — cache hit must suppress the bare probe entirely.
 	req2 := makeConnectReq(t)
-	conn2, err := connectViaProxy(req2, proxyURL, auth, cache)
+	conn2, err := ph.connectViaProxy(req2, proxyURL)
 	require.NoError(t, err, "pass 2 must succeed")
 	require.NotNil(t, conn2, "pass 2 connection must be non-nil")
 	conn2.Close()

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -435,7 +435,6 @@ type authCacheMockProxy struct {
 	bareConnects   int
 	authedConnects int
 	respondWith407 bool
-	stale407Once   bool
 }
 
 func (m *authCacheMockProxy) ServeHTTP(w http.ResponseWriter, req *http.Request) {
@@ -450,9 +449,8 @@ func (m *authCacheMockProxy) ServeHTTP(w http.ResponseWriter, req *http.Request)
 	} else {
 		m.bareConnects++
 	}
-	isFirstAuthed := m.stale407Once && hasAuth && m.authedConnects == 1
 	m.mu.Unlock()
-	if m.respondWith407 || isFirstAuthed || !hasAuth {
+	if m.respondWith407 || !hasAuth {
 		w.Header().Set("Proxy-Authenticate", "Basic realm=\"proxy\"")
 		w.WriteHeader(http.StatusProxyAuthRequired)
 		return
@@ -474,13 +472,6 @@ func newAuthCacheTestProxy(t *testing.T, respondWith407 bool) (*httptest.Server,
 	return srv, mock
 }
 
-func newStaleOnceTestProxy(t *testing.T) (*httptest.Server, *authCacheMockProxy) {
-	t.Helper()
-	mock := &authCacheMockProxy{stale407Once: true}
-	srv := httptest.NewServer(mock)
-	t.Cleanup(srv.Close)
-	return srv, mock
-}
 
 func makeConnectReq(t *testing.T) *http.Request {
 	t.Helper()
@@ -533,7 +524,7 @@ func TestConnectAuthCache_SkipsProbeOnCacheHit(t *testing.T) {
 }
 
 func TestConnectAuthCache_EvictsOnStale407(t *testing.T) {
-	proxySrv, mock := newAuthCacheTestProxy(t, true)
+	proxySrv, _ := newAuthCacheTestProxy(t, true)
 	proxyURL, err := url.Parse(proxySrv.URL)
 	require.NoError(t, err)
 	auth := newAuthChain(newBasicAuthenticator("user:pass"))
@@ -542,36 +533,11 @@ func TestConnectAuthCache_EvictsOnStale407(t *testing.T) {
 	req := makeConnectReq(t)
 	ph := ProxyHandler{auth: auth, authCache: cache}
 	_, err = ph.connectViaProxy(req, proxyURL)
-	assert.Error(t, err, "should fail when the proxy rejects all auth attempts")
+	assert.Error(t, err, "stale 407 must return an error — no self-heal")
 	_, stillCached := cache.Load(proxyURL.Host)
-	assert.False(t, stillCached, "stale cache entry must be evicted after a persistent 407")
-	bare, _ := mock.counts()
-	assert.Equal(t, 1, bare, "exactly one bare probe must be attempted after cache eviction")
+	assert.False(t, stillCached, "stale cache entry must be evicted on 407")
 }
 
-func TestConnectAuthCache_EvictsOnStale407_ThenSucceeds(t *testing.T) {
-	proxySrv, mock := newStaleOnceTestProxy(t)
-	proxyURL, err := url.Parse(proxySrv.URL)
-	require.NoError(t, err)
-	auth := newAuthChain(newBasicAuthenticator("user:pass"))
-	cache := &sync.Map{}
-	cache.Store(proxyURL.Host, proxyAuthInfo{schemes: []string{"basic"}})
-	req := makeConnectReq(t)
-	ph := ProxyHandler{auth: auth, authCache: cache}
-	conn, err := ph.connectViaProxy(req, proxyURL)
-	require.NoError(t, err, "should succeed after stale eviction and cold probe")
-	require.NotNil(t, conn, "connection must be non-nil on success")
-	conn.Close()
-	bare, _ := mock.counts()
-	assert.Equal(t, 1, bare, "exactly one bare probe must fire after stale eviction")
-	val, repopulated := cache.Load(proxyURL.Host)
-	assert.True(t, repopulated, "cache must be repopulated after successful stale re-auth")
-	if repopulated {
-		info, ok := val.(proxyAuthInfo)
-		require.True(t, ok)
-		assert.NotEmpty(t, info.schemes, "repopulated cache entry must have schemes")
-	}
-}
 
 func TestConnectAuthCache_NoProbeOnSecondRequest(t *testing.T) {
 	proxySrv, mock := newAuthCacheTestProxy(t, false)

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -450,9 +450,9 @@ func (m *authCacheMockProxy) ServeHTTP(w http.ResponseWriter, req *http.Request)
 	} else {
 		m.bareConnects++
 	}
-	isFirstBare := m.stale407Once && !hasAuth && m.bareConnects == 1
+	isFirstAuthed := m.stale407Once && hasAuth && m.authedConnects == 1
 	m.mu.Unlock()
-	if m.respondWith407 || isFirstBare || !hasAuth {
+	if m.respondWith407 || isFirstAuthed || !hasAuth {
 		w.Header().Set("Proxy-Authenticate", "Basic realm=\"proxy\"")
 		w.WriteHeader(http.StatusProxyAuthRequired)
 		return

--- a/proxyfinder.go
+++ b/proxyfinder.go
@@ -77,23 +77,26 @@ func (pf *ProxyFinder) WrapHandler(next http.Handler) http.Handler {
 
 func (pf *ProxyFinder) checkForUpdates() {
 	pf.Lock()
-	defer pf.Unlock()
 	pacjs := pf.fetcher.download()
 	if pacjs == nil {
 		if !pf.fetcher.isConnected() {
 			pf.blocked = newBlocklist()
 			pf.wrapper.Wrap(nil)
 		}
+		pf.Unlock()
 		return
 	}
 	pf.blocked = newBlocklist()
+	var notify func()
 	if err := pf.runner.Update(pacjs); err != nil {
 		log.Printf("Error running PAC JS: %q", err)
 	} else {
 		pf.wrapper.Wrap(pacjs)
-		if pf.onPACUpdate != nil {
-			pf.onPACUpdate()
-		}
+		notify = pf.onPACUpdate
+	}
+	pf.Unlock()
+	if notify != nil {
+		notify()
 	}
 }
 

--- a/proxyfinder.go
+++ b/proxyfinder.go
@@ -95,6 +95,8 @@ func (pf *ProxyFinder) checkForUpdates() {
 		notify = pf.onPACUpdate
 	}
 	pf.Unlock()
+	// Call outside the lock: the callback flushes authCache and must not re-enter
+	// any ProxyFinder-locked path, but we avoid the risk of a future deadlock here.
 	if notify != nil {
 		notify()
 	}

--- a/proxyfinder.go
+++ b/proxyfinder.go
@@ -76,29 +76,24 @@ func (pf *ProxyFinder) WrapHandler(next http.Handler) http.Handler {
 }
 
 func (pf *ProxyFinder) checkForUpdates() {
+	notify := func() {}
+	defer func() { notify() }()
 	pf.Lock()
+	defer pf.Unlock()
 	pacjs := pf.fetcher.download()
 	if pacjs == nil {
 		if !pf.fetcher.isConnected() {
 			pf.blocked = newBlocklist()
 			pf.wrapper.Wrap(nil)
 		}
-		pf.Unlock()
 		return
 	}
 	pf.blocked = newBlocklist()
-	var notify func()
 	if err := pf.runner.Update(pacjs); err != nil {
 		log.Printf("Error running PAC JS: %q", err)
 	} else {
 		pf.wrapper.Wrap(pacjs)
 		notify = pf.onPACUpdate
-	}
-	pf.Unlock()
-	// Call outside the lock: the callback flushes authCache and must not re-enter
-	// any ProxyFinder-locked path, but we avoid the risk of a future deadlock here.
-	if notify != nil {
-		notify()
 	}
 }
 

--- a/proxyfinder.go
+++ b/proxyfinder.go
@@ -93,7 +93,9 @@ func (pf *ProxyFinder) checkForUpdates() {
 		log.Printf("Error running PAC JS: %q", err)
 	} else {
 		pf.wrapper.Wrap(pacjs)
-		notify = pf.onPACUpdate
+		if pf.onPACUpdate != nil {
+			notify = pf.onPACUpdate
+		}
 	}
 }
 

--- a/proxyfinder.go
+++ b/proxyfinder.go
@@ -36,16 +36,22 @@ func getProxyFromContext(req *http.Request) (*url.URL, error) {
 }
 
 type ProxyFinder struct {
-	runner      *PACRunner
-	fetcher     *pacFetcher
-	wrapper     *PACWrapper
-	blocked     *blocklist
-	enableSocks bool
+	runner       *PACRunner
+	fetcher      *pacFetcher
+	wrapper      *PACWrapper
+	blocked      *blocklist
+	enableSocks  bool
+	onPACUpdate  func()
 	sync.Mutex
 }
 
-func NewProxyFinder(pacurl string, wrapper *PACWrapper, enableSocks bool) *ProxyFinder {
-	pf := &ProxyFinder{wrapper: wrapper, blocked: newBlocklist(), enableSocks: enableSocks}
+func NewProxyFinder(pacurl string, wrapper *PACWrapper, enableSocks bool, onPACUpdate func()) *ProxyFinder {
+	pf := &ProxyFinder{
+		wrapper:     wrapper,
+		blocked:     newBlocklist(),
+		enableSocks: enableSocks,
+		onPACUpdate: onPACUpdate,
+	}
 	pf.runner = new(PACRunner)
 	pf.fetcher = newPACFetcher(pacurl)
 	pf.checkForUpdates()
@@ -85,6 +91,9 @@ func (pf *ProxyFinder) checkForUpdates() {
 		log.Printf("Error running PAC JS: %q", err)
 	} else {
 		pf.wrapper.Wrap(pacjs)
+		if pf.onPACUpdate != nil {
+			pf.onPACUpdate()
+		}
 	}
 }
 

--- a/proxyfinder_test.go
+++ b/proxyfinder_test.go
@@ -53,7 +53,7 @@ func TestFindProxyForRequest(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(pacjsHandler(js)))
 			defer server.Close()
 			pw := NewPACWrapper(PACData{Port: 1})
-			pf := NewProxyFinder(server.URL, pw, test.enableSocks)
+			pf := NewProxyFinder(server.URL, pw, test.enableSocks, nil)
 			req := httptest.NewRequest(http.MethodGet, "https://www.test", nil)
 			ctx := context.WithValue(req.Context(), contextKeyID, i)
 			req = req.WithContext(ctx)
@@ -76,7 +76,7 @@ func TestFindProxyForRequest(t *testing.T) {
 func TestFallbackToDirectWhenNotConnected(t *testing.T) {
 	url := "http://pacserver.invalid/nonexistent.pac"
 	pw := NewPACWrapper(PACData{Port: 1})
-	pf := NewProxyFinder(url, pw, false)
+	pf := NewProxyFinder(url, pw, false, nil)
 	req := httptest.NewRequest(http.MethodGet, "http://www.test", nil)
 	proxy, err := pf.findProxyForRequest(req)
 	require.NoError(t, err)
@@ -86,12 +86,29 @@ func TestFallbackToDirectWhenNotConnected(t *testing.T) {
 // Removed TestFallbackToDirectWhenNoPACURL. Behaviour is fallback to system default when no
 // PACURL; see test case TestFallbackToDefaultWhenNoPACUrl.
 
+func TestProxyFinder_CallsOnPACUpdate(t *testing.T) {
+	js := `function FindProxyForURL(url, host) { return "DIRECT" }`
+	server := httptest.NewServer(http.HandlerFunc(pacjsHandler(js)))
+	defer server.Close()
+	pw := NewPACWrapper(PACData{Port: 1})
+	called := false
+	NewProxyFinder(server.URL, pw, false, func() { called = true })
+	assert.True(t, called, "onPACUpdate should be called on successful PAC download")
+}
+
+func TestProxyFinder_DoesNotCallOnPACUpdateWhenUnreachable(t *testing.T) {
+	pw := NewPACWrapper(PACData{Port: 1})
+	called := false
+	NewProxyFinder("http://pacserver.invalid/nonexistent.pac", pw, false, func() { called = true })
+	assert.False(t, called, "onPACUpdate should not be called when PAC server is unreachable")
+}
+
 func TestSkipBadProxies(t *testing.T) {
 	js := `function FindProxyForURL(url, host) { return "PROXY primary:80; PROXY backup:80" }`
 	server := httptest.NewServer(http.HandlerFunc(pacjsHandler(js)))
 	defer server.Close()
 	pw := NewPACWrapper(PACData{Port: 1})
-	pf := NewProxyFinder(server.URL, pw, false)
+	pf := NewProxyFinder(server.URL, pw, false, nil)
 	req := httptest.NewRequest(http.MethodGet, "https://www.test", nil)
 	ctx := context.WithValue(req.Context(), contextKeyID, 0)
 	req = req.WithContext(ctx)


### PR DESCRIPTION
 ### Summary

Adds a per-session auth cache (keyed on proxy host) to ProxyHandler. After the first CONNECT tunnel to a proxy receives a 407, the advertised schemes are cached. Subsequent tunnels skip the unauthenticated probe and go straight to authentication.
Net result: One 407 on session warm-up, zero on every subsequent CONNECT to the same proxy host. A stale entry self-heals in one extra round-trip.

### What's added
- proxyAuthInfo struct — holds the schemes advertised in a proxy's 407 response.
- authCache *sync.Map on ProxyHandler — per-session cache keyed on proxy host, initialised in NewProxyHandler.
- Phase 1 / Phase 2 split in connectViaProxy — Phase 1 (cache hit) skips the unauthenticated probe and calls retryConnectWithAuth directly with cached schemes. Phase 2 (cache miss) is the original behaviour; on 407 it populates the cache before retrying.
- Stale-entry eviction — a cache hit that returns 407 evicts the entry, runs a cold probe on a fresh transport, and repopulates on successful re-auth.
- onPACUpdate func() hook on ProxyFinder — called after every successful PAC re-download; wired in main.go to flush the cache so network topology changes (VPN, Wi-Fi switch) clear stale entries automatically. Kept it simple, because this could have been a rabbit hole. As that old adage goes:
> "There are only two hard things in Computer Science: _cache invalidation_, naming things, and off-by-one errors." - Leon Bambrick
- Seven new tests — five TestConnectAuthCache_* in proxy_test.go covering cache population, probe suppression, stale eviction (persistent 407), stale eviction then success, and the two-pass probe-count assertion requested in #181; two TestProxyFinder_* confirming the PAC flush callback fires on re-download and not on failure.

### What's changed (with why)
- connectViaProxy gains a 4th authCache *sync.Map parameter. Two existing call sites in multiauth_integration_test.go updated to pass &sync.Map{}.
- req.Header.Del("Proxy-Authorization") before the cold probe in the stale-eviction path. After retryConnectWithAuth runs, the request carries a residual auth header — clearing it    ensures the cold probe is genuinely unauthenticated.
- RFC 7235 §4.3 updated to RFC 9110 §11.3 throughout.

### How to validate
Manual: with a live NTLM proxy, the first CONNECT logs a 407 handshake; all subsequent CONNECTs go straight to Attempting NTLM authentication with no preceding 407. Verified on Windows against a corporate NTLM proxy. Screencap with redacted info below)
<img width="1591" height="569" alt="image" src="https://github.com/user-attachments/assets/c24ab972-3edb-4820-82ac-ea929038300f" />

### Notes for review
- Plain HTTP path (proxyRequest) is unchanged — NTLM persistence there is handled by Go's transport layer.
- No LRU cap — as discussed in #181, the cache is keyed on PAC-sourced proxy hosts (trusted, bounded), not arbitrary web server hosts. Firefox has no cap either.
- onPACUpdate callback design was discussed and confirmed in #181. Construction order in main.go (ProxyHandler before ProxyFinder) is load-bearing — noted in a comment.
- Fixes #181
